### PR TITLE
Build and test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  ci:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache protobuf build
+      id: protocache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/src/protobuf-3.16.0
+        key: protobuf-3.16.0
+
+    - name: Compile protobuf
+      if: steps.protocache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get install -y autoconf automake libtool curl make g++ unzip
+
+        mkdir ~/src
+        curl -#fsSL https://github.com/protocolbuffers/protobuf/releases/download/v3.16.0/protobuf-all-3.16.0.tar.gz | tar -xzvf - -C ~/src
+
+        cd ~/src/protobuf-3.16.0
+        mkdir bin
+        ./configure --prefix=$PWD/bin
+        make
+        make check
+        sudo make install
+        sudo ldconfig # refresh shared library cache.
+        cp bin/bin/protoc ~/src/protobuf-3.16.0/src/
+        make -C conformance
+        ls -lh ~/src/protobuf-3.16.0/conformance/conformance-test-runner
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13'
+
+    - uses: actions/checkout@v2
+
+    - run: make genall
+    # TODO(fenollp): these files shouldn't be modified
+    - run: |
+        git --no-pager diff
+        git checkout -- conformance/internal/conformance/conformance_vtproto.pb.go
+        git checkout -- conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+        git checkout -- conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+        git checkout -- testproto/proto3opt/opt_vtproto.pb.go
+    - run: git --no-pager diff --exit-code
+
+    - run: go test -count=1 ./conformance/...
+      env:
+        PROTOBUF_ROOT: /home/runner/src/protobuf-3.16.0
+    - run: git --no-pager diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ gen-testproto:
 			--go_out=. --plugin protoc-gen-go="${GOBIN}/protoc-gen-go" \
 			--go-vtproto_out=. --plugin protoc-gen-go-vtproto="${GOBIN}/protoc-gen-go-vtproto" \
 			-I$(PROTOBUF_ROOT)/src \
-			testproto/$${name}; \
+			testproto/$${name} || exit 1; \
   	done
 
 genall: install gen-include gen-conformance gen-testproto


### PR DESCRIPTION
I had to build protobuf as this is the only way I found to obtain `conformance-test-runner`. This build is cached but first runs (for example any new pull request) will take a 30min-ish hit.
I can remove this time to zero by caching somewhere less temporary such as some Docker image in this repo's registry. What do you think?

While setting this up I noticed some generated files where out of sync with git. Should I add their diff to this PR?

<details>
<summary>Details</summary>

```diff
diff --git a/conformance/internal/conformance/conformance_vtproto.pb.go b/conformance/internal/conformance/conformance_vtproto.pb.go
index 980bbd5..8d6971f 100644
--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -89,19 +89,9 @@ func (m *ConformanceRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.PrintUnknownFields {
-		i--
-		if m.PrintUnknownFields {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x48
-	}
 	if vtmsg, ok := m.Payload.(interface {
-		MarshalToVT([]byte) (int, error)
-		SizeVT() int
+		MarshalTo([]byte) (int, error)
+		Size() int
 	}); ok {
 		{
 			size := vtmsg.SizeVT()
@@ -[11](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:11)1,6 +101,16 @@ func (m *ConformanceRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			}
 		}
 	}
+	if m.PrintUnknownFields {
+		i--
+		if m.PrintUnknownFields {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
 	if m.JspbEncodingOptions != nil {
 		size, err := m.JspbEncodingOptions.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -228,8 +228,8 @@ func (m *ConformanceResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if vtmsg, ok := m.Result.(interface {
-		MarshalToVT([]byte) (int, error)
-		SizeVT() int
+		MarshalTo([]byte) (int, error)
+		Size() int
 	}); ok {
 		{
 			size := vtmsg.SizeVT()
diff --git a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
index 23972ed..119b4be 100644
--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -259,6 +259,18 @@ func (m *TestAllTypesProto2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if vtmsg, ok := m.OneofField.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if m.FieldName18__ != nil {
 		i = encodeVarint(dAtA, i, uint64(*m.FieldName18__))
 		i--
@@ -400,18 +4[12](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:12),6 @@ func (m *TestAllTypesProto2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0xcb
 	}
-	if vtmsg, ok := m.OneofField.(interface {
-		MarshalToVT([]byte) (int, error)
-		SizeVT() int
-	}); ok {
-		{
-			size := vtmsg.SizeVT()
-			i -= size
-			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
-				return 0, err
-			}
-		}
-	}
 	if len(m.UnpackedNestedEnum) > 0 {
 		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
 			i = encodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
diff --git a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
index 76f05a8..d5fecd2 100644
--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -104,6 +104,18 @@ func (m *TestAllTypesProto3) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if vtmsg, ok := m.OneofField.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if m.FieldName18__ != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.FieldName18__))
 		i--
@@ -10[13](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:13),18 +1025,6 @@ func (m *TestAllTypesProto3) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0xca
 	}
-	if vtmsg, ok := m.OneofField.(interface {
-		MarshalToVT([]byte) (int, error)
-		SizeVT() int
-	}); ok {
-		{
-			size := vtmsg.SizeVT()
-			i -= size
-			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
-				return 0, err
-			}
-		}
-	}
 	if len(m.UnpackedNestedEnum) > 0 {
 		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
 			i = encodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
diff --git a/testproto/proto3opt/opt_vtproto.pb.go b/testproto/proto3opt/opt_vtproto.pb.go
index 726b[15](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:15)c..[16](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:16)a5e8b 100644
--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -50,6 +50,[19](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:19)8 @@ func (m *OptionalFieldInProto3) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if vtmsg, ok := m.XOptionalEnum.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalBytes.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalString.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalBool.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalDouble.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalFloat.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalSfixed64.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalSfixed[32](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:32).(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalFixed[64](https://github.com/fenollp/vtprotobuf/runs/5318361134?check_suite_focus=true#step:7:64).(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalFixed32.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalSint64.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalSint32.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalUint64.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalUint32.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalInt64.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if vtmsg, ok := m.XOptionalInt32.(interface {
+		MarshalTo([]byte) (int, error)
+		Size() int
+	}); ok {
+		{
+			size := vtmsg.SizeVT()
+			i -= size
+			if _, err := vtmsg.MarshalToVT(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if m.OptionalEnum != nil {
 		i = encodeVarint(dAtA, i, uint64(*m.OptionalEnum))
 		i--
```


</details>

