### PR TITLE
Drop github.com/gogo/protobuf as it is unused

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export PROTOBUF_ROOT=$(HOME)/src/protobuf-3.16.0
 install:
 	go install -tags protolegacy google.golang.org/protobuf/cmd/protoc-gen-go
 	go install -tags protolegacy ./cmd/protoc-gen-go-vtproto
-	go install -tags protolegacy github.com/gogo/protobuf/protoc-gen-gofast
+# 	go install -tags protolegacy github.com/gogo/protobuf/protoc-gen-gofast
 
 gen-conformance:
 	$(PROTOBUF_ROOT)/src/protoc \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/planetscale/vtprotobuf
 go 1.16
 
 require (
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384
 	google.golang.org/protobuf v1.26.0


### PR DESCRIPTION
This seems to have slipped into the go.mod while doing some testing against previous (gogo) implementations of features (such as size).

It is not needed by any package in this repo and makes its way into dependent modules. Removing this should be safe.

We can wait on https://github.com/planetscale/vtprotobuf/pull/29 to the rebase & see CI is green.
