### PR TITLE
clone: generate unrolled code for cloning messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ The following features can be generated:
 
     - `func YourProtoFromVTPool() *YourProto`: this function returns a `YourProto` message from a local memory pool, or allocates a new one if the pool is currently empty. The returned message is always empty and ready to be used (e.g. by calling `UnmarshalVT` on it). Once the message has been processed, it must be returned to the memory pool by calling `ReturnToVTPool()` on it. Returning the message to the pool is not mandatory (it does not leak memory), but if you don't return it, that defeats the whole point of memory pooling.
 
+- `clone`: generates the following helper methods
+
+    - `func (p *YourProto) CloneVT() *YourProto`: this function behaves similarly to calling `proto.Clone(p)` on the message, except the cloning is performed by unrolled codegen without using reflection. If the receiver `p` is `nil` a typed `nil` is returned.
+
+    - `func (p *YourProto) CloneGenericVT() proto.Message`: this function behaves like the above `p.CloneVT()`, but provides a uniform signature in order to be accessible via type assertions even if the type is not known at compile time. This allows implementing a generic `func CloneVT(proto.Message)` without reflection. If the receiver `p` is `nil`, a typed `nil` pointer of the message type will be returned inside a `proto.Message` interface.
+
 ## Usage
 
 1. Install `protoc-gen-go-vtproto`:

--- a/cmd/protoc-gen-go-vtproto/main.go
+++ b/cmd/protoc-gen-go-vtproto/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	_ "github.com/planetscale/vtprotobuf/features/clone"
 	_ "github.com/planetscale/vtprotobuf/features/equal"
 	_ "github.com/planetscale/vtprotobuf/features/grpc"
 	_ "github.com/planetscale/vtprotobuf/features/marshal"

--- a/conformance/internal/conformance/clonevt_test.go
+++ b/conformance/internal/conformance/clonevt_test.go
@@ -2,11 +2,12 @@ package conformance
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"testing"
 )
 
 func TestCloneVTNil(t *testing.T) {

--- a/conformance/internal/conformance/clonevt_test.go
+++ b/conformance/internal/conformance/clonevt_test.go
@@ -1,0 +1,98 @@
+package conformance
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"testing"
+)
+
+func TestCloneVTNil(t *testing.T) {
+	var a *TestAllTypesProto2
+	b := a.CloneVT()
+	require.Nil(t, b)
+}
+
+func TestCloneVT2(t *testing.T) {
+	stringPtr := func(x string) *string { return &x }
+	float32Ptr := func(x float32) *float32 { return &x }
+	float64Ptr := func(x float64) *float64 { return &x }
+
+	msgs := []*TestAllTypesProto2{
+		{OptionalString: stringPtr("bla")},
+		{OptionalDouble: float64Ptr(1.7976931348623157e+308)},
+		{OptionalFloat: float32Ptr(-0.0)},
+		{OptionalBytes: []byte{}},
+		{MapStringBytes: map[string][]byte{"": {}}},
+		{OneofField: &TestAllTypesProto2_OneofBool{OneofBool: false}},
+		{MapStringNestedMessage: map[string]*TestAllTypesProto2_NestedMessage{"": {}}},
+		{MapStringNestedMessage: map[string]*TestAllTypesProto2_NestedMessage{"eh": {}}},
+	}
+
+	for _, msg := range msgs {
+		t.Run(fmt.Sprintf("%+v", msg), func(t *testing.T) {
+			orig := proto.Clone(msg).(*TestAllTypesProto2)
+			clone := orig.CloneVT()
+			require.Truef(t, clone.EqualVT(msg), "cloning %T returned modified message:\nmsg = %+v\nclone = %+v\n", msg, msg, clone)
+			require.Truef(t, orig.EqualVT(msg), "cloning %T modified original message:\nmsg = %+v\nafter clone = %+v\n", msg, msg, clone)
+
+			MutateFields(clone)
+			require.False(t, clone.EqualVT(msg), "cloned message unchanged after mutation")
+			require.True(t, orig.EqualVT(msg), "mutating cloned %T mutated original:\nmsg = %+v\nafter clone = %+v\n", msg, msg, orig)
+		})
+	}
+}
+
+func TestCloneVT3(t *testing.T) {
+	msg := &TestAllTypesProto3{
+		OneofField: &TestAllTypesProto3_OneofNullValue{OneofNullValue: structpb.NullValue_NULL_VALUE},
+
+		OptionalBoolWrapper:   wrapperspb.Bool(true),
+		OptionalInt32Wrapper:  wrapperspb.Int32(1),
+		OptionalInt64Wrapper:  wrapperspb.Int64(1),
+		OptionalUint32Wrapper: wrapperspb.UInt32(1),
+		OptionalUint64Wrapper: wrapperspb.UInt64(1),
+		OptionalFloatWrapper:  wrapperspb.Float(1),
+		OptionalDoubleWrapper: wrapperspb.Double(1),
+		OptionalStringWrapper: wrapperspb.String("blip"),
+		OptionalBytesWrapper:  wrapperspb.Bytes([]byte("blop")),
+
+		RepeatedBoolWrapper:   []*wrapperspb.BoolValue{wrapperspb.Bool(true)},
+		RepeatedInt32Wrapper:  []*wrapperspb.Int32Value{wrapperspb.Int32(1)},
+		RepeatedInt64Wrapper:  []*wrapperspb.Int64Value{wrapperspb.Int64(1)},
+		RepeatedUint32Wrapper: []*wrapperspb.UInt32Value{wrapperspb.UInt32(1)},
+		RepeatedUint64Wrapper: []*wrapperspb.UInt64Value{wrapperspb.UInt64(1)},
+		RepeatedFloatWrapper:  []*wrapperspb.FloatValue{wrapperspb.Float(1)},
+		RepeatedDoubleWrapper: []*wrapperspb.DoubleValue{wrapperspb.Double(1)},
+		RepeatedStringWrapper: []*wrapperspb.StringValue{wrapperspb.String("blip")},
+		RepeatedBytesWrapper:  []*wrapperspb.BytesValue{wrapperspb.Bytes([]byte("blop"))},
+
+		// OptionalDuration:      *durationpb.Duration
+		// OptionalTimestamp:     *timestamppb.Timestamp
+		// OptionalFieldMask:     *fieldmaskpb.FieldMask
+		// OptionalStruct:        *structpb.Struct
+		// OptionalAny:           *anypb.Any
+		OptionalValue: structpb.NewNumberValue(42),
+		// OptionalNullValue:     structpb.NullValue
+
+		// repeated google.protobuf.Duration repeated_duration
+		// repeated google.protobuf.Timestamp repeated_timestamp
+		// repeated google.protobuf.FieldMask repeated_fieldmask
+		// repeated google.protobuf.Struct repeated_struct
+		// repeated google.protobuf.Any repeated_any
+		// repeated google.protobuf.Value repeated_value
+		RepeatedValue: []*structpb.Value{structpb.NewNumberValue(42)},
+		// repeated google.protobuf.ListValue repeated_list_value
+	}
+
+	orig := proto.Clone(msg).(*TestAllTypesProto3)
+	clone := orig.CloneVT()
+	require.Truef(t, clone.EqualVT(msg), "cloning %T returned modified message:\nmsg = %+v\nclone = %+v\n", msg, msg, clone)
+	require.Truef(t, orig.EqualVT(msg), "cloning %T modified original message:\nmsg = %+v\nafter clone = %+v\n", msg, msg, clone)
+
+	MutateFields(clone)
+	require.False(t, clone.EqualVT(msg), "cloned message unchanged after mutation")
+	require.True(t, orig.EqualVT(msg), "mutating cloned %T mutated original:\nmsg = %+v\nafter clone = %+v\n", msg, msg, orig)
+}

--- a/conformance/internal/conformance/conformance.pb.go
+++ b/conformance/internal/conformance/conformance.pb.go
@@ -223,9 +223,9 @@ func (x *FailureSet) GetFailure() []string {
 
 // Represents a single test case's input.  The testee should:
 //
-//   1. parse this proto (which should always succeed)
-//   2. parse the protobuf or JSON payload in "payload" (which may fail)
-//   3. if the parse succeeded, serialize the message in the requested format.
+//  1. parse this proto (which should always succeed)
+//  2. parse the protobuf or JSON payload in "payload" (which may fail)
+//  3. if the parse succeeded, serialize the message in the requested format.
 type ConformanceRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -240,6 +240,7 @@ type ConformanceRequest struct {
 	// protobuf_test_messages.google.protobuf.TestAllTypes message instead.
 	//
 	// Types that are assignable to Payload:
+	//
 	//	*ConformanceRequest_ProtobufPayload
 	//	*ConformanceRequest_JsonPayload
 	//	*ConformanceRequest_JspbPayload
@@ -400,6 +401,7 @@ type ConformanceResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Result:
+	//
 	//	*ConformanceResponse_ParseError
 	//	*ConformanceResponse_SerializeError
 	//	*ConformanceResponse_RuntimeError

--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -6,6 +6,7 @@ package conformance
 
 import (
 	fmt "fmt"
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 )
@@ -16,6 +17,203 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *FailureSet) CloneVT() *FailureSet {
+	if m == nil {
+		return (*FailureSet)(nil)
+	}
+	r := &FailureSet{}
+	if rhs := m.Failure; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Failure = tmpContainer
+	}
+	return r
+}
+
+func (m *FailureSet) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ConformanceRequest) CloneVT() *ConformanceRequest {
+	if m == nil {
+		return (*ConformanceRequest)(nil)
+	}
+	r := &ConformanceRequest{
+		RequestedOutputFormat: m.RequestedOutputFormat,
+		MessageType:           m.MessageType,
+		TestCategory:          m.TestCategory,
+		JspbEncodingOptions:   m.JspbEncodingOptions.CloneVT(),
+		PrintUnknownFields:    m.PrintUnknownFields,
+	}
+	if m.Payload != nil {
+		r.Payload = m.Payload.(interface {
+			CloneVT() isConformanceRequest_Payload
+		}).CloneVT()
+	}
+	return r
+}
+
+func (m *ConformanceRequest) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ConformanceRequest_ProtobufPayload) CloneVT() isConformanceRequest_Payload {
+	if m == nil {
+		return (*ConformanceRequest_ProtobufPayload)(nil)
+	}
+	r := &ConformanceRequest_ProtobufPayload{}
+	if rhs := m.ProtobufPayload; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.ProtobufPayload = tmpBytes
+	}
+	return r
+}
+
+func (m *ConformanceRequest_JsonPayload) CloneVT() isConformanceRequest_Payload {
+	if m == nil {
+		return (*ConformanceRequest_JsonPayload)(nil)
+	}
+	r := &ConformanceRequest_JsonPayload{
+		JsonPayload: m.JsonPayload,
+	}
+	return r
+}
+
+func (m *ConformanceRequest_JspbPayload) CloneVT() isConformanceRequest_Payload {
+	if m == nil {
+		return (*ConformanceRequest_JspbPayload)(nil)
+	}
+	r := &ConformanceRequest_JspbPayload{
+		JspbPayload: m.JspbPayload,
+	}
+	return r
+}
+
+func (m *ConformanceRequest_TextPayload) CloneVT() isConformanceRequest_Payload {
+	if m == nil {
+		return (*ConformanceRequest_TextPayload)(nil)
+	}
+	r := &ConformanceRequest_TextPayload{
+		TextPayload: m.TextPayload,
+	}
+	return r
+}
+
+func (m *ConformanceResponse) CloneVT() *ConformanceResponse {
+	if m == nil {
+		return (*ConformanceResponse)(nil)
+	}
+	r := &ConformanceResponse{}
+	if m.Result != nil {
+		r.Result = m.Result.(interface {
+			CloneVT() isConformanceResponse_Result
+		}).CloneVT()
+	}
+	return r
+}
+
+func (m *ConformanceResponse) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ConformanceResponse_ParseError) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_ParseError)(nil)
+	}
+	r := &ConformanceResponse_ParseError{
+		ParseError: m.ParseError,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_SerializeError) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_SerializeError)(nil)
+	}
+	r := &ConformanceResponse_SerializeError{
+		SerializeError: m.SerializeError,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_RuntimeError) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_RuntimeError)(nil)
+	}
+	r := &ConformanceResponse_RuntimeError{
+		RuntimeError: m.RuntimeError,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_ProtobufPayload) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_ProtobufPayload)(nil)
+	}
+	r := &ConformanceResponse_ProtobufPayload{}
+	if rhs := m.ProtobufPayload; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.ProtobufPayload = tmpBytes
+	}
+	return r
+}
+
+func (m *ConformanceResponse_JsonPayload) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_JsonPayload)(nil)
+	}
+	r := &ConformanceResponse_JsonPayload{
+		JsonPayload: m.JsonPayload,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_Skipped) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_Skipped)(nil)
+	}
+	r := &ConformanceResponse_Skipped{
+		Skipped: m.Skipped,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_JspbPayload) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_JspbPayload)(nil)
+	}
+	r := &ConformanceResponse_JspbPayload{
+		JspbPayload: m.JspbPayload,
+	}
+	return r
+}
+
+func (m *ConformanceResponse_TextPayload) CloneVT() isConformanceResponse_Result {
+	if m == nil {
+		return (*ConformanceResponse_TextPayload)(nil)
+	}
+	r := &ConformanceResponse_TextPayload{
+		TextPayload: m.TextPayload,
+	}
+	return r
+}
+
+func (m *JspbEncodingConfig) CloneVT() *JspbEncodingConfig {
+	if m == nil {
+		return (*JspbEncodingConfig)(nil)
+	}
+	r := &JspbEncodingConfig{
+		UseJspbArrayAnyFormat: m.UseJspbArrayAnyFormat,
+	}
+	return r
+}
+
+func (m *JspbEncodingConfig) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (this *FailureSet) EqualVT(that *FailureSet) bool {
 	if this == nil {

--- a/conformance/internal/conformance/test_messages_proto2.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2.pb.go
@@ -344,6 +344,7 @@ type TestAllTypesProto2 struct {
 	MapStringNestedEnum     map[string]TestAllTypesProto2_NestedEnum     `protobuf:"bytes,73,rep,name=map_string_nested_enum,json=mapStringNestedEnum" json:"map_string_nested_enum,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value,enum=protobuf_test_messages.proto2.TestAllTypesProto2_NestedEnum"`
 	MapStringForeignEnum    map[string]ForeignEnumProto2                 `protobuf:"bytes,74,rep,name=map_string_foreign_enum,json=mapStringForeignEnum" json:"map_string_foreign_enum,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value,enum=protobuf_test_messages.proto2.ForeignEnumProto2"`
 	// Types that are assignable to OneofField:
+	//
 	//	*TestAllTypesProto2_OneofUint32
 	//	*TestAllTypesProto2_OneofNestedMessage
 	//	*TestAllTypesProto2_OneofString

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -21,6 +21,905 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *TestAllTypesProto2_NestedMessage) CloneVT() *TestAllTypesProto2_NestedMessage {
+	if m == nil {
+		return (*TestAllTypesProto2_NestedMessage)(nil)
+	}
+	r := &TestAllTypesProto2_NestedMessage{
+		Corecursive: m.Corecursive.CloneVT(),
+	}
+	if rhs := m.A; rhs != nil {
+		tmpVal := *rhs
+		r.A = &tmpVal
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_NestedMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2_Data) CloneVT() *TestAllTypesProto2_Data {
+	if m == nil {
+		return (*TestAllTypesProto2_Data)(nil)
+	}
+	r := &TestAllTypesProto2_Data{}
+	if rhs := m.GroupInt32; rhs != nil {
+		tmpVal := *rhs
+		r.GroupInt32 = &tmpVal
+	}
+	if rhs := m.GroupUint32; rhs != nil {
+		tmpVal := *rhs
+		r.GroupUint32 = &tmpVal
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_Data) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) CloneVT() *TestAllTypesProto2_MessageSetCorrect {
+	if m == nil {
+		return (*TestAllTypesProto2_MessageSetCorrect)(nil)
+	}
+	r := &TestAllTypesProto2_MessageSetCorrect{}
+	return r
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneVT() *TestAllTypesProto2_MessageSetCorrectExtension1 {
+	if m == nil {
+		return (*TestAllTypesProto2_MessageSetCorrectExtension1)(nil)
+	}
+	r := &TestAllTypesProto2_MessageSetCorrectExtension1{}
+	if rhs := m.Str; rhs != nil {
+		tmpVal := *rhs
+		r.Str = &tmpVal
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneVT() *TestAllTypesProto2_MessageSetCorrectExtension2 {
+	if m == nil {
+		return (*TestAllTypesProto2_MessageSetCorrectExtension2)(nil)
+	}
+	r := &TestAllTypesProto2_MessageSetCorrectExtension2{}
+	if rhs := m.I; rhs != nil {
+		tmpVal := *rhs
+		r.I = &tmpVal
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2) CloneVT() *TestAllTypesProto2 {
+	if m == nil {
+		return (*TestAllTypesProto2)(nil)
+	}
+	r := &TestAllTypesProto2{
+		OptionalNestedMessage:  m.OptionalNestedMessage.CloneVT(),
+		OptionalForeignMessage: m.OptionalForeignMessage.CloneVT(),
+		RecursiveMessage:       m.RecursiveMessage.CloneVT(),
+		Data:                   m.Data.CloneVT(),
+	}
+	if rhs := m.OptionalInt32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalInt32 = &tmpVal
+	}
+	if rhs := m.OptionalInt64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalInt64 = &tmpVal
+	}
+	if rhs := m.OptionalUint32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalUint32 = &tmpVal
+	}
+	if rhs := m.OptionalUint64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalUint64 = &tmpVal
+	}
+	if rhs := m.OptionalSint32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSint32 = &tmpVal
+	}
+	if rhs := m.OptionalSint64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSint64 = &tmpVal
+	}
+	if rhs := m.OptionalFixed32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFixed32 = &tmpVal
+	}
+	if rhs := m.OptionalFixed64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFixed64 = &tmpVal
+	}
+	if rhs := m.OptionalSfixed32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSfixed32 = &tmpVal
+	}
+	if rhs := m.OptionalSfixed64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSfixed64 = &tmpVal
+	}
+	if rhs := m.OptionalFloat; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFloat = &tmpVal
+	}
+	if rhs := m.OptionalDouble; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalDouble = &tmpVal
+	}
+	if rhs := m.OptionalBool; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalBool = &tmpVal
+	}
+	if rhs := m.OptionalString; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalString = &tmpVal
+	}
+	if rhs := m.OptionalBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OptionalBytes = tmpBytes
+	}
+	if rhs := m.OptionalNestedEnum; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalNestedEnum = &tmpVal
+	}
+	if rhs := m.OptionalForeignEnum; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalForeignEnum = &tmpVal
+	}
+	if rhs := m.OptionalStringPiece; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalStringPiece = &tmpVal
+	}
+	if rhs := m.OptionalCord; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalCord = &tmpVal
+	}
+	if rhs := m.RepeatedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedInt32 = tmpContainer
+	}
+	if rhs := m.RepeatedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedInt64 = tmpContainer
+	}
+	if rhs := m.RepeatedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedUint32 = tmpContainer
+	}
+	if rhs := m.RepeatedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedUint64 = tmpContainer
+	}
+	if rhs := m.RepeatedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSint32 = tmpContainer
+	}
+	if rhs := m.RepeatedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSint64 = tmpContainer
+	}
+	if rhs := m.RepeatedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFixed32 = tmpContainer
+	}
+	if rhs := m.RepeatedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFixed64 = tmpContainer
+	}
+	if rhs := m.RepeatedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSfixed32 = tmpContainer
+	}
+	if rhs := m.RepeatedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSfixed64 = tmpContainer
+	}
+	if rhs := m.RepeatedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFloat = tmpContainer
+	}
+	if rhs := m.RepeatedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedDouble = tmpContainer
+	}
+	if rhs := m.RepeatedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedBool = tmpContainer
+	}
+	if rhs := m.RepeatedString; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedString = tmpContainer
+	}
+	if rhs := m.RepeatedBytes; rhs != nil {
+		tmpContainer := make([][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.RepeatedBytes = tmpContainer
+	}
+	if rhs := m.RepeatedNestedMessage; rhs != nil {
+		tmpContainer := make([]*TestAllTypesProto2_NestedMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.RepeatedNestedMessage = tmpContainer
+	}
+	if rhs := m.RepeatedForeignMessage; rhs != nil {
+		tmpContainer := make([]*ForeignMessageProto2, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.RepeatedForeignMessage = tmpContainer
+	}
+	if rhs := m.RepeatedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto2_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedNestedEnum = tmpContainer
+	}
+	if rhs := m.RepeatedForeignEnum; rhs != nil {
+		tmpContainer := make([]ForeignEnumProto2, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedForeignEnum = tmpContainer
+	}
+	if rhs := m.RepeatedStringPiece; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedStringPiece = tmpContainer
+	}
+	if rhs := m.RepeatedCord; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedCord = tmpContainer
+	}
+	if rhs := m.PackedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedInt32 = tmpContainer
+	}
+	if rhs := m.PackedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedInt64 = tmpContainer
+	}
+	if rhs := m.PackedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedUint32 = tmpContainer
+	}
+	if rhs := m.PackedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedUint64 = tmpContainer
+	}
+	if rhs := m.PackedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSint32 = tmpContainer
+	}
+	if rhs := m.PackedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSint64 = tmpContainer
+	}
+	if rhs := m.PackedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFixed32 = tmpContainer
+	}
+	if rhs := m.PackedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFixed64 = tmpContainer
+	}
+	if rhs := m.PackedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSfixed32 = tmpContainer
+	}
+	if rhs := m.PackedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSfixed64 = tmpContainer
+	}
+	if rhs := m.PackedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFloat = tmpContainer
+	}
+	if rhs := m.PackedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedDouble = tmpContainer
+	}
+	if rhs := m.PackedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedBool = tmpContainer
+	}
+	if rhs := m.PackedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto2_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedNestedEnum = tmpContainer
+	}
+	if rhs := m.UnpackedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedInt32 = tmpContainer
+	}
+	if rhs := m.UnpackedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedInt64 = tmpContainer
+	}
+	if rhs := m.UnpackedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedUint32 = tmpContainer
+	}
+	if rhs := m.UnpackedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedUint64 = tmpContainer
+	}
+	if rhs := m.UnpackedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSint32 = tmpContainer
+	}
+	if rhs := m.UnpackedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSint64 = tmpContainer
+	}
+	if rhs := m.UnpackedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFixed32 = tmpContainer
+	}
+	if rhs := m.UnpackedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFixed64 = tmpContainer
+	}
+	if rhs := m.UnpackedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSfixed32 = tmpContainer
+	}
+	if rhs := m.UnpackedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSfixed64 = tmpContainer
+	}
+	if rhs := m.UnpackedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFloat = tmpContainer
+	}
+	if rhs := m.UnpackedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedDouble = tmpContainer
+	}
+	if rhs := m.UnpackedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedBool = tmpContainer
+	}
+	if rhs := m.UnpackedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto2_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedNestedEnum = tmpContainer
+	}
+	if rhs := m.MapInt32Int32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Int32 = tmpContainer
+	}
+	if rhs := m.MapInt64Int64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt64Int64 = tmpContainer
+	}
+	if rhs := m.MapUint32Uint32; rhs != nil {
+		tmpContainer := make(map[uint32]uint32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapUint32Uint32 = tmpContainer
+	}
+	if rhs := m.MapUint64Uint64; rhs != nil {
+		tmpContainer := make(map[uint64]uint64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapUint64Uint64 = tmpContainer
+	}
+	if rhs := m.MapSint32Sint32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSint32Sint32 = tmpContainer
+	}
+	if rhs := m.MapSint64Sint64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSint64Sint64 = tmpContainer
+	}
+	if rhs := m.MapFixed32Fixed32; rhs != nil {
+		tmpContainer := make(map[uint32]uint32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapFixed32Fixed32 = tmpContainer
+	}
+	if rhs := m.MapFixed64Fixed64; rhs != nil {
+		tmpContainer := make(map[uint64]uint64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapFixed64Fixed64 = tmpContainer
+	}
+	if rhs := m.MapSfixed32Sfixed32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSfixed32Sfixed32 = tmpContainer
+	}
+	if rhs := m.MapSfixed64Sfixed64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSfixed64Sfixed64 = tmpContainer
+	}
+	if rhs := m.MapInt32Float; rhs != nil {
+		tmpContainer := make(map[int32]float32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Float = tmpContainer
+	}
+	if rhs := m.MapInt32Double; rhs != nil {
+		tmpContainer := make(map[int32]float64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Double = tmpContainer
+	}
+	if rhs := m.MapBoolBool; rhs != nil {
+		tmpContainer := make(map[bool]bool, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapBoolBool = tmpContainer
+	}
+	if rhs := m.MapStringString; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringString = tmpContainer
+	}
+	if rhs := m.MapStringBytes; rhs != nil {
+		tmpContainer := make(map[string][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.MapStringBytes = tmpContainer
+	}
+	if rhs := m.MapStringNestedMessage; rhs != nil {
+		tmpContainer := make(map[string]*TestAllTypesProto2_NestedMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.MapStringNestedMessage = tmpContainer
+	}
+	if rhs := m.MapStringForeignMessage; rhs != nil {
+		tmpContainer := make(map[string]*ForeignMessageProto2, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.MapStringForeignMessage = tmpContainer
+	}
+	if rhs := m.MapStringNestedEnum; rhs != nil {
+		tmpContainer := make(map[string]TestAllTypesProto2_NestedEnum, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringNestedEnum = tmpContainer
+	}
+	if rhs := m.MapStringForeignEnum; rhs != nil {
+		tmpContainer := make(map[string]ForeignEnumProto2, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringForeignEnum = tmpContainer
+	}
+	if m.OneofField != nil {
+		r.OneofField = m.OneofField.(interface {
+			CloneVT() isTestAllTypesProto2_OneofField
+		}).CloneVT()
+	}
+	if rhs := m.DefaultInt32; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultInt32 = &tmpVal
+	}
+	if rhs := m.DefaultInt64; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultInt64 = &tmpVal
+	}
+	if rhs := m.DefaultUint32; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultUint32 = &tmpVal
+	}
+	if rhs := m.DefaultUint64; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultUint64 = &tmpVal
+	}
+	if rhs := m.DefaultSint32; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultSint32 = &tmpVal
+	}
+	if rhs := m.DefaultSint64; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultSint64 = &tmpVal
+	}
+	if rhs := m.DefaultFixed32; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultFixed32 = &tmpVal
+	}
+	if rhs := m.DefaultFixed64; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultFixed64 = &tmpVal
+	}
+	if rhs := m.DefaultSfixed32; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultSfixed32 = &tmpVal
+	}
+	if rhs := m.DefaultSfixed64; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultSfixed64 = &tmpVal
+	}
+	if rhs := m.DefaultFloat; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultFloat = &tmpVal
+	}
+	if rhs := m.DefaultDouble; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultDouble = &tmpVal
+	}
+	if rhs := m.DefaultBool; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultBool = &tmpVal
+	}
+	if rhs := m.DefaultString; rhs != nil {
+		tmpVal := *rhs
+		r.DefaultString = &tmpVal
+	}
+	if rhs := m.DefaultBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.DefaultBytes = tmpBytes
+	}
+	if rhs := m.Fieldname1; rhs != nil {
+		tmpVal := *rhs
+		r.Fieldname1 = &tmpVal
+	}
+	if rhs := m.FieldName2; rhs != nil {
+		tmpVal := *rhs
+		r.FieldName2 = &tmpVal
+	}
+	if rhs := m.XFieldName3; rhs != nil {
+		tmpVal := *rhs
+		r.XFieldName3 = &tmpVal
+	}
+	if rhs := m.Field_Name4_; rhs != nil {
+		tmpVal := *rhs
+		r.Field_Name4_ = &tmpVal
+	}
+	if rhs := m.Field0Name5; rhs != nil {
+		tmpVal := *rhs
+		r.Field0Name5 = &tmpVal
+	}
+	if rhs := m.Field_0Name6; rhs != nil {
+		tmpVal := *rhs
+		r.Field_0Name6 = &tmpVal
+	}
+	if rhs := m.FieldName7; rhs != nil {
+		tmpVal := *rhs
+		r.FieldName7 = &tmpVal
+	}
+	if rhs := m.FieldName8; rhs != nil {
+		tmpVal := *rhs
+		r.FieldName8 = &tmpVal
+	}
+	if rhs := m.Field_Name9; rhs != nil {
+		tmpVal := *rhs
+		r.Field_Name9 = &tmpVal
+	}
+	if rhs := m.Field_Name10; rhs != nil {
+		tmpVal := *rhs
+		r.Field_Name10 = &tmpVal
+	}
+	if rhs := m.FIELD_NAME11; rhs != nil {
+		tmpVal := *rhs
+		r.FIELD_NAME11 = &tmpVal
+	}
+	if rhs := m.FIELDName12; rhs != nil {
+		tmpVal := *rhs
+		r.FIELDName12 = &tmpVal
+	}
+	if rhs := m.XFieldName13; rhs != nil {
+		tmpVal := *rhs
+		r.XFieldName13 = &tmpVal
+	}
+	if rhs := m.X_FieldName14; rhs != nil {
+		tmpVal := *rhs
+		r.X_FieldName14 = &tmpVal
+	}
+	if rhs := m.Field_Name15; rhs != nil {
+		tmpVal := *rhs
+		r.Field_Name15 = &tmpVal
+	}
+	if rhs := m.Field__Name16; rhs != nil {
+		tmpVal := *rhs
+		r.Field__Name16 = &tmpVal
+	}
+	if rhs := m.FieldName17__; rhs != nil {
+		tmpVal := *rhs
+		r.FieldName17__ = &tmpVal
+	}
+	if rhs := m.FieldName18__; rhs != nil {
+		tmpVal := *rhs
+		r.FieldName18__ = &tmpVal
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto2_OneofUint32) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofUint32)(nil)
+	}
+	r := &TestAllTypesProto2_OneofUint32{
+		OneofUint32: m.OneofUint32,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofNestedMessage) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofNestedMessage)(nil)
+	}
+	r := &TestAllTypesProto2_OneofNestedMessage{
+		OneofNestedMessage: m.OneofNestedMessage.CloneVT(),
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofString) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofString)(nil)
+	}
+	r := &TestAllTypesProto2_OneofString{
+		OneofString: m.OneofString,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofBytes) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofBytes)(nil)
+	}
+	r := &TestAllTypesProto2_OneofBytes{}
+	if rhs := m.OneofBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OneofBytes = tmpBytes
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofBool) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofBool)(nil)
+	}
+	r := &TestAllTypesProto2_OneofBool{
+		OneofBool: m.OneofBool,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofUint64) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofUint64)(nil)
+	}
+	r := &TestAllTypesProto2_OneofUint64{
+		OneofUint64: m.OneofUint64,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofFloat) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofFloat)(nil)
+	}
+	r := &TestAllTypesProto2_OneofFloat{
+		OneofFloat: m.OneofFloat,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofDouble) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofDouble)(nil)
+	}
+	r := &TestAllTypesProto2_OneofDouble{
+		OneofDouble: m.OneofDouble,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto2_OneofEnum) CloneVT() isTestAllTypesProto2_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto2_OneofEnum)(nil)
+	}
+	r := &TestAllTypesProto2_OneofEnum{
+		OneofEnum: m.OneofEnum,
+	}
+	return r
+}
+
+func (m *ForeignMessageProto2) CloneVT() *ForeignMessageProto2 {
+	if m == nil {
+		return (*ForeignMessageProto2)(nil)
+	}
+	r := &ForeignMessageProto2{}
+	if rhs := m.C; rhs != nil {
+		tmpVal := *rhs
+		r.C = &tmpVal
+	}
+	return r
+}
+
+func (m *ForeignMessageProto2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) CloneVT() *UnknownToTestAllTypes_OptionalGroup {
+	if m == nil {
+		return (*UnknownToTestAllTypes_OptionalGroup)(nil)
+	}
+	r := &UnknownToTestAllTypes_OptionalGroup{}
+	if rhs := m.A; rhs != nil {
+		tmpVal := *rhs
+		r.A = &tmpVal
+	}
+	return r
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *UnknownToTestAllTypes) CloneVT() *UnknownToTestAllTypes {
+	if m == nil {
+		return (*UnknownToTestAllTypes)(nil)
+	}
+	r := &UnknownToTestAllTypes{
+		NestedMessage: m.NestedMessage.CloneVT(),
+		Optionalgroup: m.Optionalgroup.CloneVT(),
+	}
+	if rhs := m.OptionalInt32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalInt32 = &tmpVal
+	}
+	if rhs := m.OptionalString; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalString = &tmpVal
+	}
+	if rhs := m.OptionalBool; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalBool = &tmpVal
+	}
+	if rhs := m.RepeatedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedInt32 = tmpContainer
+	}
+	return r
+}
+
+func (m *UnknownToTestAllTypes) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *NullHypothesisProto2) CloneVT() *NullHypothesisProto2 {
+	if m == nil {
+		return (*NullHypothesisProto2)(nil)
+	}
+	r := &NullHypothesisProto2{}
+	return r
+}
+
+func (m *NullHypothesisProto2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *EnumOnlyProto2) CloneVT() *EnumOnlyProto2 {
+	if m == nil {
+		return (*EnumOnlyProto2)(nil)
+	}
+	r := &EnumOnlyProto2{}
+	return r
+}
+
+func (m *EnumOnlyProto2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *OneStringProto2) CloneVT() *OneStringProto2 {
+	if m == nil {
+		return (*OneStringProto2)(nil)
+	}
+	r := &OneStringProto2{}
+	if rhs := m.Data; rhs != nil {
+		tmpVal := *rhs
+		r.Data = &tmpVal
+	}
+	return r
+}
+
+func (m *OneStringProto2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *TestAllTypesProto2_NestedMessage) EqualVT(that *TestAllTypesProto2_NestedMessage) bool {
 	if this == nil {
 		return that == nil || that.String() == ""

--- a/conformance/internal/conformance/test_messages_proto3.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3.pb.go
@@ -377,6 +377,7 @@ type TestAllTypesProto3 struct {
 	MapStringNestedEnum     map[string]TestAllTypesProto3_NestedEnum     `protobuf:"bytes,73,rep,name=map_string_nested_enum,json=mapStringNestedEnum,proto3" json:"map_string_nested_enum,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=protobuf_test_messages.proto3.TestAllTypesProto3_NestedEnum"`
 	MapStringForeignEnum    map[string]ForeignEnum                       `protobuf:"bytes,74,rep,name=map_string_foreign_enum,json=mapStringForeignEnum,proto3" json:"map_string_foreign_enum,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=protobuf_test_messages.proto3.ForeignEnum"`
 	// Types that are assignable to OneofField:
+	//
 	//	*TestAllTypesProto3_OneofUint32
 	//	*TestAllTypesProto3_OneofNestedMessage
 	//	*TestAllTypesProto3_OneofString

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -17,6 +17,7 @@ import (
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	io "io"
 	math "math"
+	reflect "reflect"
 )
 
 const (
@@ -25,6 +26,947 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *TestAllTypesProto3_NestedMessage) CloneVT() *TestAllTypesProto3_NestedMessage {
+	if m == nil {
+		return (*TestAllTypesProto3_NestedMessage)(nil)
+	}
+	r := &TestAllTypesProto3_NestedMessage{
+		A:           m.A,
+		Corecursive: m.Corecursive.CloneVT(),
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_NestedMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
+	if m == nil {
+		return (*TestAllTypesProto3)(nil)
+	}
+	r := &TestAllTypesProto3{
+		OptionalInt32:          m.OptionalInt32,
+		OptionalInt64:          m.OptionalInt64,
+		OptionalUint32:         m.OptionalUint32,
+		OptionalUint64:         m.OptionalUint64,
+		OptionalSint32:         m.OptionalSint32,
+		OptionalSint64:         m.OptionalSint64,
+		OptionalFixed32:        m.OptionalFixed32,
+		OptionalFixed64:        m.OptionalFixed64,
+		OptionalSfixed32:       m.OptionalSfixed32,
+		OptionalSfixed64:       m.OptionalSfixed64,
+		OptionalFloat:          m.OptionalFloat,
+		OptionalDouble:         m.OptionalDouble,
+		OptionalBool:           m.OptionalBool,
+		OptionalString:         m.OptionalString,
+		OptionalNestedMessage:  m.OptionalNestedMessage.CloneVT(),
+		OptionalForeignMessage: m.OptionalForeignMessage.CloneVT(),
+		OptionalNestedEnum:     m.OptionalNestedEnum,
+		OptionalForeignEnum:    m.OptionalForeignEnum,
+		OptionalAliasedEnum:    m.OptionalAliasedEnum,
+		OptionalStringPiece:    m.OptionalStringPiece,
+		OptionalCord:           m.OptionalCord,
+		RecursiveMessage:       m.RecursiveMessage.CloneVT(),
+		OptionalBoolWrapper:    vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue(m.OptionalBoolWrapper),
+		OptionalInt32Wrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value(m.OptionalInt32Wrapper),
+		OptionalInt64Wrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value(m.OptionalInt64Wrapper),
+		OptionalUint32Wrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value(m.OptionalUint32Wrapper),
+		OptionalUint64Wrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value(m.OptionalUint64Wrapper),
+		OptionalFloatWrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue(m.OptionalFloatWrapper),
+		OptionalDoubleWrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue(m.OptionalDoubleWrapper),
+		OptionalStringWrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_StringValue(m.OptionalStringWrapper),
+		OptionalBytesWrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue(m.OptionalBytesWrapper),
+		OptionalDuration:       vt_clone_helper__test_messages_proto3__google_protobuf_Duration(m.OptionalDuration),
+		OptionalTimestamp:      vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp(m.OptionalTimestamp),
+		OptionalFieldMask:      vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask(m.OptionalFieldMask),
+		OptionalStruct:         vt_clone_helper__test_messages_proto3__google_protobuf_Struct(m.OptionalStruct),
+		OptionalAny:            vt_clone_helper__test_messages_proto3__google_protobuf_Any(m.OptionalAny),
+		OptionalValue:          vt_clone_helper__test_messages_proto3__google_protobuf_Value(m.OptionalValue),
+		OptionalNullValue:      m.OptionalNullValue,
+		Fieldname1:             m.Fieldname1,
+		FieldName2:             m.FieldName2,
+		XFieldName3:            m.XFieldName3,
+		Field_Name4_:           m.Field_Name4_,
+		Field0Name5:            m.Field0Name5,
+		Field_0Name6:           m.Field_0Name6,
+		FieldName7:             m.FieldName7,
+		FieldName8:             m.FieldName8,
+		Field_Name9:            m.Field_Name9,
+		Field_Name10:           m.Field_Name10,
+		FIELD_NAME11:           m.FIELD_NAME11,
+		FIELDName12:            m.FIELDName12,
+		XFieldName13:           m.XFieldName13,
+		X_FieldName14:          m.X_FieldName14,
+		Field_Name15:           m.Field_Name15,
+		Field__Name16:          m.Field__Name16,
+		FieldName17__:          m.FieldName17__,
+		FieldName18__:          m.FieldName18__,
+	}
+	if rhs := m.OptionalBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OptionalBytes = tmpBytes
+	}
+	if rhs := m.RepeatedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedInt32 = tmpContainer
+	}
+	if rhs := m.RepeatedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedInt64 = tmpContainer
+	}
+	if rhs := m.RepeatedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedUint32 = tmpContainer
+	}
+	if rhs := m.RepeatedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedUint64 = tmpContainer
+	}
+	if rhs := m.RepeatedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSint32 = tmpContainer
+	}
+	if rhs := m.RepeatedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSint64 = tmpContainer
+	}
+	if rhs := m.RepeatedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFixed32 = tmpContainer
+	}
+	if rhs := m.RepeatedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFixed64 = tmpContainer
+	}
+	if rhs := m.RepeatedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSfixed32 = tmpContainer
+	}
+	if rhs := m.RepeatedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedSfixed64 = tmpContainer
+	}
+	if rhs := m.RepeatedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedFloat = tmpContainer
+	}
+	if rhs := m.RepeatedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedDouble = tmpContainer
+	}
+	if rhs := m.RepeatedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedBool = tmpContainer
+	}
+	if rhs := m.RepeatedString; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedString = tmpContainer
+	}
+	if rhs := m.RepeatedBytes; rhs != nil {
+		tmpContainer := make([][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.RepeatedBytes = tmpContainer
+	}
+	if rhs := m.RepeatedNestedMessage; rhs != nil {
+		tmpContainer := make([]*TestAllTypesProto3_NestedMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.RepeatedNestedMessage = tmpContainer
+	}
+	if rhs := m.RepeatedForeignMessage; rhs != nil {
+		tmpContainer := make([]*ForeignMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.RepeatedForeignMessage = tmpContainer
+	}
+	if rhs := m.RepeatedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto3_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedNestedEnum = tmpContainer
+	}
+	if rhs := m.RepeatedForeignEnum; rhs != nil {
+		tmpContainer := make([]ForeignEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedForeignEnum = tmpContainer
+	}
+	if rhs := m.RepeatedStringPiece; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedStringPiece = tmpContainer
+	}
+	if rhs := m.RepeatedCord; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedCord = tmpContainer
+	}
+	if rhs := m.PackedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedInt32 = tmpContainer
+	}
+	if rhs := m.PackedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedInt64 = tmpContainer
+	}
+	if rhs := m.PackedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedUint32 = tmpContainer
+	}
+	if rhs := m.PackedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedUint64 = tmpContainer
+	}
+	if rhs := m.PackedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSint32 = tmpContainer
+	}
+	if rhs := m.PackedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSint64 = tmpContainer
+	}
+	if rhs := m.PackedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFixed32 = tmpContainer
+	}
+	if rhs := m.PackedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFixed64 = tmpContainer
+	}
+	if rhs := m.PackedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSfixed32 = tmpContainer
+	}
+	if rhs := m.PackedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedSfixed64 = tmpContainer
+	}
+	if rhs := m.PackedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedFloat = tmpContainer
+	}
+	if rhs := m.PackedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedDouble = tmpContainer
+	}
+	if rhs := m.PackedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedBool = tmpContainer
+	}
+	if rhs := m.PackedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto3_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedNestedEnum = tmpContainer
+	}
+	if rhs := m.UnpackedInt32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedInt32 = tmpContainer
+	}
+	if rhs := m.UnpackedInt64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedInt64 = tmpContainer
+	}
+	if rhs := m.UnpackedUint32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedUint32 = tmpContainer
+	}
+	if rhs := m.UnpackedUint64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedUint64 = tmpContainer
+	}
+	if rhs := m.UnpackedSint32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSint32 = tmpContainer
+	}
+	if rhs := m.UnpackedSint64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSint64 = tmpContainer
+	}
+	if rhs := m.UnpackedFixed32; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFixed32 = tmpContainer
+	}
+	if rhs := m.UnpackedFixed64; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFixed64 = tmpContainer
+	}
+	if rhs := m.UnpackedSfixed32; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSfixed32 = tmpContainer
+	}
+	if rhs := m.UnpackedSfixed64; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedSfixed64 = tmpContainer
+	}
+	if rhs := m.UnpackedFloat; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedFloat = tmpContainer
+	}
+	if rhs := m.UnpackedDouble; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedDouble = tmpContainer
+	}
+	if rhs := m.UnpackedBool; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedBool = tmpContainer
+	}
+	if rhs := m.UnpackedNestedEnum; rhs != nil {
+		tmpContainer := make([]TestAllTypesProto3_NestedEnum, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnpackedNestedEnum = tmpContainer
+	}
+	if rhs := m.MapInt32Int32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Int32 = tmpContainer
+	}
+	if rhs := m.MapInt64Int64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt64Int64 = tmpContainer
+	}
+	if rhs := m.MapUint32Uint32; rhs != nil {
+		tmpContainer := make(map[uint32]uint32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapUint32Uint32 = tmpContainer
+	}
+	if rhs := m.MapUint64Uint64; rhs != nil {
+		tmpContainer := make(map[uint64]uint64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapUint64Uint64 = tmpContainer
+	}
+	if rhs := m.MapSint32Sint32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSint32Sint32 = tmpContainer
+	}
+	if rhs := m.MapSint64Sint64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSint64Sint64 = tmpContainer
+	}
+	if rhs := m.MapFixed32Fixed32; rhs != nil {
+		tmpContainer := make(map[uint32]uint32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapFixed32Fixed32 = tmpContainer
+	}
+	if rhs := m.MapFixed64Fixed64; rhs != nil {
+		tmpContainer := make(map[uint64]uint64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapFixed64Fixed64 = tmpContainer
+	}
+	if rhs := m.MapSfixed32Sfixed32; rhs != nil {
+		tmpContainer := make(map[int32]int32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSfixed32Sfixed32 = tmpContainer
+	}
+	if rhs := m.MapSfixed64Sfixed64; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapSfixed64Sfixed64 = tmpContainer
+	}
+	if rhs := m.MapInt32Float; rhs != nil {
+		tmpContainer := make(map[int32]float32, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Float = tmpContainer
+	}
+	if rhs := m.MapInt32Double; rhs != nil {
+		tmpContainer := make(map[int32]float64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapInt32Double = tmpContainer
+	}
+	if rhs := m.MapBoolBool; rhs != nil {
+		tmpContainer := make(map[bool]bool, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapBoolBool = tmpContainer
+	}
+	if rhs := m.MapStringString; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringString = tmpContainer
+	}
+	if rhs := m.MapStringBytes; rhs != nil {
+		tmpContainer := make(map[string][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.MapStringBytes = tmpContainer
+	}
+	if rhs := m.MapStringNestedMessage; rhs != nil {
+		tmpContainer := make(map[string]*TestAllTypesProto3_NestedMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.MapStringNestedMessage = tmpContainer
+	}
+	if rhs := m.MapStringForeignMessage; rhs != nil {
+		tmpContainer := make(map[string]*ForeignMessage, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.MapStringForeignMessage = tmpContainer
+	}
+	if rhs := m.MapStringNestedEnum; rhs != nil {
+		tmpContainer := make(map[string]TestAllTypesProto3_NestedEnum, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringNestedEnum = tmpContainer
+	}
+	if rhs := m.MapStringForeignEnum; rhs != nil {
+		tmpContainer := make(map[string]ForeignEnum, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MapStringForeignEnum = tmpContainer
+	}
+	if m.OneofField != nil {
+		r.OneofField = m.OneofField.(interface {
+			CloneVT() isTestAllTypesProto3_OneofField
+		}).CloneVT()
+	}
+	if rhs := m.RepeatedBoolWrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.BoolValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue(v)
+		}
+		r.RepeatedBoolWrapper = tmpContainer
+	}
+	if rhs := m.RepeatedInt32Wrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.Int32Value, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value(v)
+		}
+		r.RepeatedInt32Wrapper = tmpContainer
+	}
+	if rhs := m.RepeatedInt64Wrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.Int64Value, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value(v)
+		}
+		r.RepeatedInt64Wrapper = tmpContainer
+	}
+	if rhs := m.RepeatedUint32Wrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.UInt32Value, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value(v)
+		}
+		r.RepeatedUint32Wrapper = tmpContainer
+	}
+	if rhs := m.RepeatedUint64Wrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.UInt64Value, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value(v)
+		}
+		r.RepeatedUint64Wrapper = tmpContainer
+	}
+	if rhs := m.RepeatedFloatWrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.FloatValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue(v)
+		}
+		r.RepeatedFloatWrapper = tmpContainer
+	}
+	if rhs := m.RepeatedDoubleWrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.DoubleValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue(v)
+		}
+		r.RepeatedDoubleWrapper = tmpContainer
+	}
+	if rhs := m.RepeatedStringWrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.StringValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_StringValue(v)
+		}
+		r.RepeatedStringWrapper = tmpContainer
+	}
+	if rhs := m.RepeatedBytesWrapper; rhs != nil {
+		tmpContainer := make([]*wrapperspb.BytesValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue(v)
+		}
+		r.RepeatedBytesWrapper = tmpContainer
+	}
+	if rhs := m.RepeatedDuration; rhs != nil {
+		tmpContainer := make([]*durationpb.Duration, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Duration(v)
+		}
+		r.RepeatedDuration = tmpContainer
+	}
+	if rhs := m.RepeatedTimestamp; rhs != nil {
+		tmpContainer := make([]*timestamppb.Timestamp, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp(v)
+		}
+		r.RepeatedTimestamp = tmpContainer
+	}
+	if rhs := m.RepeatedFieldmask; rhs != nil {
+		tmpContainer := make([]*fieldmaskpb.FieldMask, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask(v)
+		}
+		r.RepeatedFieldmask = tmpContainer
+	}
+	if rhs := m.RepeatedStruct; rhs != nil {
+		tmpContainer := make([]*structpb.Struct, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Struct(v)
+		}
+		r.RepeatedStruct = tmpContainer
+	}
+	if rhs := m.RepeatedAny; rhs != nil {
+		tmpContainer := make([]*anypb.Any, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Any(v)
+		}
+		r.RepeatedAny = tmpContainer
+	}
+	if rhs := m.RepeatedValue; rhs != nil {
+		tmpContainer := make([]*structpb.Value, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Value(v)
+		}
+		r.RepeatedValue = tmpContainer
+	}
+	if rhs := m.RepeatedListValue; rhs != nil {
+		tmpContainer := make([]*structpb.ListValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_ListValue(v)
+		}
+		r.RepeatedListValue = tmpContainer
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TestAllTypesProto3_OneofUint32) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofUint32)(nil)
+	}
+	r := &TestAllTypesProto3_OneofUint32{
+		OneofUint32: m.OneofUint32,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofNestedMessage) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofNestedMessage)(nil)
+	}
+	r := &TestAllTypesProto3_OneofNestedMessage{
+		OneofNestedMessage: m.OneofNestedMessage.CloneVT(),
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofString) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofString)(nil)
+	}
+	r := &TestAllTypesProto3_OneofString{
+		OneofString: m.OneofString,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofBytes) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofBytes)(nil)
+	}
+	r := &TestAllTypesProto3_OneofBytes{}
+	if rhs := m.OneofBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OneofBytes = tmpBytes
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofBool) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofBool)(nil)
+	}
+	r := &TestAllTypesProto3_OneofBool{
+		OneofBool: m.OneofBool,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofUint64) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofUint64)(nil)
+	}
+	r := &TestAllTypesProto3_OneofUint64{
+		OneofUint64: m.OneofUint64,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofFloat) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofFloat)(nil)
+	}
+	r := &TestAllTypesProto3_OneofFloat{
+		OneofFloat: m.OneofFloat,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofDouble) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofDouble)(nil)
+	}
+	r := &TestAllTypesProto3_OneofDouble{
+		OneofDouble: m.OneofDouble,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofEnum) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofEnum)(nil)
+	}
+	r := &TestAllTypesProto3_OneofEnum{
+		OneofEnum: m.OneofEnum,
+	}
+	return r
+}
+
+func (m *TestAllTypesProto3_OneofNullValue) CloneVT() isTestAllTypesProto3_OneofField {
+	if m == nil {
+		return (*TestAllTypesProto3_OneofNullValue)(nil)
+	}
+	r := &TestAllTypesProto3_OneofNullValue{
+		OneofNullValue: m.OneofNullValue,
+	}
+	return r
+}
+
+func (m *ForeignMessage) CloneVT() *ForeignMessage {
+	if m == nil {
+		return (*ForeignMessage)(nil)
+	}
+	r := &ForeignMessage{
+		C: m.C,
+	}
+	return r
+}
+
+func (m *ForeignMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *NullHypothesisProto3) CloneVT() *NullHypothesisProto3 {
+	if m == nil {
+		return (*NullHypothesisProto3)(nil)
+	}
+	r := &NullHypothesisProto3{}
+	return r
+}
+
+func (m *NullHypothesisProto3) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *EnumOnlyProto3) CloneVT() *EnumOnlyProto3 {
+	if m == nil {
+		return (*EnumOnlyProto3)(nil)
+	}
+	r := &EnumOnlyProto3{}
+	return r
+}
+
+func (m *EnumOnlyProto3) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+var (
+	vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value  func(*wrapperspb.Int64Value) *wrapperspb.Int64Value
+	vt_clone_helper__test_messages_proto3__google_protobuf_StringValue func(*wrapperspb.StringValue) *wrapperspb.StringValue
+	vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp   func(*timestamppb.Timestamp) *timestamppb.Timestamp
+	vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask   func(*fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask
+	vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue  func(*wrapperspb.FloatValue) *wrapperspb.FloatValue
+	vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue func(*wrapperspb.DoubleValue) *wrapperspb.DoubleValue
+	vt_clone_helper__test_messages_proto3__google_protobuf_Any         func(*anypb.Any) *anypb.Any
+	vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue   func(*wrapperspb.BoolValue) *wrapperspb.BoolValue
+	vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value func(*wrapperspb.UInt64Value) *wrapperspb.UInt64Value
+	vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue  func(*wrapperspb.BytesValue) *wrapperspb.BytesValue
+	vt_clone_helper__test_messages_proto3__google_protobuf_Duration    func(*durationpb.Duration) *durationpb.Duration
+	vt_clone_helper__test_messages_proto3__google_protobuf_Struct      func(*structpb.Struct) *structpb.Struct
+	vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value  func(*wrapperspb.Int32Value) *wrapperspb.Int32Value
+	vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value func(*wrapperspb.UInt32Value) *wrapperspb.UInt32Value
+	vt_clone_helper__test_messages_proto3__google_protobuf_Value       func(*structpb.Value) *structpb.Value
+	vt_clone_helper__test_messages_proto3__google_protobuf_ListValue   func(*structpb.ListValue) *structpb.ListValue
+)
+
+func init() {
+	if _, ok := proto.Message((*wrapperspb.Int64Value)(nil)).(interface{ CloneVT() *wrapperspb.Int64Value }); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.Int64Value)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value = m.Func.Interface().(func(*wrapperspb.Int64Value) *wrapperspb.Int64Value)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value = func(m *wrapperspb.Int64Value) *wrapperspb.Int64Value {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.Int64Value)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.StringValue)(nil)).(interface {
+		CloneVT() *wrapperspb.StringValue
+	}); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.StringValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_StringValue = m.Func.Interface().(func(*wrapperspb.StringValue) *wrapperspb.StringValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_StringValue = func(m *wrapperspb.StringValue) *wrapperspb.StringValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.StringValue)
+		}
+	}
+	if _, ok := proto.Message((*timestamppb.Timestamp)(nil)).(interface{ CloneVT() *timestamppb.Timestamp }); ok {
+		m, _ := reflect.TypeOf((*timestamppb.Timestamp)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp = m.Func.Interface().(func(*timestamppb.Timestamp) *timestamppb.Timestamp)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp = func(m *timestamppb.Timestamp) *timestamppb.Timestamp {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*timestamppb.Timestamp)
+		}
+	}
+	if _, ok := proto.Message((*fieldmaskpb.FieldMask)(nil)).(interface{ CloneVT() *fieldmaskpb.FieldMask }); ok {
+		m, _ := reflect.TypeOf((*fieldmaskpb.FieldMask)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask = m.Func.Interface().(func(*fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask = func(m *fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*fieldmaskpb.FieldMask)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.FloatValue)(nil)).(interface{ CloneVT() *wrapperspb.FloatValue }); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.FloatValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue = m.Func.Interface().(func(*wrapperspb.FloatValue) *wrapperspb.FloatValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue = func(m *wrapperspb.FloatValue) *wrapperspb.FloatValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.FloatValue)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.DoubleValue)(nil)).(interface {
+		CloneVT() *wrapperspb.DoubleValue
+	}); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.DoubleValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue = m.Func.Interface().(func(*wrapperspb.DoubleValue) *wrapperspb.DoubleValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue = func(m *wrapperspb.DoubleValue) *wrapperspb.DoubleValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.DoubleValue)
+		}
+	}
+	if _, ok := proto.Message((*anypb.Any)(nil)).(interface{ CloneVT() *anypb.Any }); ok {
+		m, _ := reflect.TypeOf((*anypb.Any)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Any = m.Func.Interface().(func(*anypb.Any) *anypb.Any)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Any = func(m *anypb.Any) *anypb.Any {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*anypb.Any)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.BoolValue)(nil)).(interface{ CloneVT() *wrapperspb.BoolValue }); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.BoolValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue = m.Func.Interface().(func(*wrapperspb.BoolValue) *wrapperspb.BoolValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue = func(m *wrapperspb.BoolValue) *wrapperspb.BoolValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.BoolValue)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.UInt64Value)(nil)).(interface {
+		CloneVT() *wrapperspb.UInt64Value
+	}); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.UInt64Value)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value = m.Func.Interface().(func(*wrapperspb.UInt64Value) *wrapperspb.UInt64Value)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value = func(m *wrapperspb.UInt64Value) *wrapperspb.UInt64Value {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.UInt64Value)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.BytesValue)(nil)).(interface{ CloneVT() *wrapperspb.BytesValue }); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.BytesValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue = m.Func.Interface().(func(*wrapperspb.BytesValue) *wrapperspb.BytesValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue = func(m *wrapperspb.BytesValue) *wrapperspb.BytesValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.BytesValue)
+		}
+	}
+	if _, ok := proto.Message((*durationpb.Duration)(nil)).(interface{ CloneVT() *durationpb.Duration }); ok {
+		m, _ := reflect.TypeOf((*durationpb.Duration)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Duration = m.Func.Interface().(func(*durationpb.Duration) *durationpb.Duration)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Duration = func(m *durationpb.Duration) *durationpb.Duration {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*durationpb.Duration)
+		}
+	}
+	if _, ok := proto.Message((*structpb.Struct)(nil)).(interface{ CloneVT() *structpb.Struct }); ok {
+		m, _ := reflect.TypeOf((*structpb.Struct)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Struct = m.Func.Interface().(func(*structpb.Struct) *structpb.Struct)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Struct = func(m *structpb.Struct) *structpb.Struct {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*structpb.Struct)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.Int32Value)(nil)).(interface{ CloneVT() *wrapperspb.Int32Value }); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.Int32Value)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value = m.Func.Interface().(func(*wrapperspb.Int32Value) *wrapperspb.Int32Value)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value = func(m *wrapperspb.Int32Value) *wrapperspb.Int32Value {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.Int32Value)
+		}
+	}
+	if _, ok := proto.Message((*wrapperspb.UInt32Value)(nil)).(interface {
+		CloneVT() *wrapperspb.UInt32Value
+	}); ok {
+		m, _ := reflect.TypeOf((*wrapperspb.UInt32Value)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value = m.Func.Interface().(func(*wrapperspb.UInt32Value) *wrapperspb.UInt32Value)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value = func(m *wrapperspb.UInt32Value) *wrapperspb.UInt32Value {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*wrapperspb.UInt32Value)
+		}
+	}
+	if _, ok := proto.Message((*structpb.Value)(nil)).(interface{ CloneVT() *structpb.Value }); ok {
+		m, _ := reflect.TypeOf((*structpb.Value)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_Value = m.Func.Interface().(func(*structpb.Value) *structpb.Value)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_Value = func(m *structpb.Value) *structpb.Value {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*structpb.Value)
+		}
+	}
+	if _, ok := proto.Message((*structpb.ListValue)(nil)).(interface{ CloneVT() *structpb.ListValue }); ok {
+		m, _ := reflect.TypeOf((*structpb.ListValue)(nil)).MethodByName("CloneVT")
+		vt_clone_helper__test_messages_proto3__google_protobuf_ListValue = m.Func.Interface().(func(*structpb.ListValue) *structpb.ListValue)
+	} else {
+		vt_clone_helper__test_messages_proto3__google_protobuf_ListValue = func(m *structpb.ListValue) *structpb.ListValue {
+			if m == nil {
+				return nil
+			}
+			return proto.Clone(m).(*structpb.ListValue)
+		}
+	}
+}
 
 func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_NestedMessage) bool {
 	if this == nil {

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -17,7 +17,6 @@ import (
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	io "io"
 	math "math"
-	reflect "reflect"
 )
 
 const (
@@ -69,21 +68,6 @@ func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
 		OptionalStringPiece:    m.OptionalStringPiece,
 		OptionalCord:           m.OptionalCord,
 		RecursiveMessage:       m.RecursiveMessage.CloneVT(),
-		OptionalBoolWrapper:    vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue(m.OptionalBoolWrapper),
-		OptionalInt32Wrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value(m.OptionalInt32Wrapper),
-		OptionalInt64Wrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value(m.OptionalInt64Wrapper),
-		OptionalUint32Wrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value(m.OptionalUint32Wrapper),
-		OptionalUint64Wrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value(m.OptionalUint64Wrapper),
-		OptionalFloatWrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue(m.OptionalFloatWrapper),
-		OptionalDoubleWrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue(m.OptionalDoubleWrapper),
-		OptionalStringWrapper:  vt_clone_helper__test_messages_proto3__google_protobuf_StringValue(m.OptionalStringWrapper),
-		OptionalBytesWrapper:   vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue(m.OptionalBytesWrapper),
-		OptionalDuration:       vt_clone_helper__test_messages_proto3__google_protobuf_Duration(m.OptionalDuration),
-		OptionalTimestamp:      vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp(m.OptionalTimestamp),
-		OptionalFieldMask:      vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask(m.OptionalFieldMask),
-		OptionalStruct:         vt_clone_helper__test_messages_proto3__google_protobuf_Struct(m.OptionalStruct),
-		OptionalAny:            vt_clone_helper__test_messages_proto3__google_protobuf_Any(m.OptionalAny),
-		OptionalValue:          vt_clone_helper__test_messages_proto3__google_protobuf_Value(m.OptionalValue),
 		OptionalNullValue:      m.OptionalNullValue,
 		Fieldname1:             m.Fieldname1,
 		FieldName2:             m.FieldName2,
@@ -502,115 +486,300 @@ func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
 			CloneVT() isTestAllTypesProto3_OneofField
 		}).CloneVT()
 	}
+	if rhs := m.OptionalBoolWrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *wrapperspb.BoolValue }); ok {
+			r.OptionalBoolWrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalBoolWrapper = proto.Clone(rhs).(*wrapperspb.BoolValue)
+		}
+	}
+	if rhs := m.OptionalInt32Wrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *wrapperspb.Int32Value }); ok {
+			r.OptionalInt32Wrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalInt32Wrapper = proto.Clone(rhs).(*wrapperspb.Int32Value)
+		}
+	}
+	if rhs := m.OptionalInt64Wrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *wrapperspb.Int64Value }); ok {
+			r.OptionalInt64Wrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalInt64Wrapper = proto.Clone(rhs).(*wrapperspb.Int64Value)
+		}
+	}
+	if rhs := m.OptionalUint32Wrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *wrapperspb.UInt32Value
+		}); ok {
+			r.OptionalUint32Wrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalUint32Wrapper = proto.Clone(rhs).(*wrapperspb.UInt32Value)
+		}
+	}
+	if rhs := m.OptionalUint64Wrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *wrapperspb.UInt64Value
+		}); ok {
+			r.OptionalUint64Wrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalUint64Wrapper = proto.Clone(rhs).(*wrapperspb.UInt64Value)
+		}
+	}
+	if rhs := m.OptionalFloatWrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *wrapperspb.FloatValue }); ok {
+			r.OptionalFloatWrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalFloatWrapper = proto.Clone(rhs).(*wrapperspb.FloatValue)
+		}
+	}
+	if rhs := m.OptionalDoubleWrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *wrapperspb.DoubleValue
+		}); ok {
+			r.OptionalDoubleWrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalDoubleWrapper = proto.Clone(rhs).(*wrapperspb.DoubleValue)
+		}
+	}
+	if rhs := m.OptionalStringWrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *wrapperspb.StringValue
+		}); ok {
+			r.OptionalStringWrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalStringWrapper = proto.Clone(rhs).(*wrapperspb.StringValue)
+		}
+	}
+	if rhs := m.OptionalBytesWrapper; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *wrapperspb.BytesValue }); ok {
+			r.OptionalBytesWrapper = vtpb.CloneVT()
+		} else {
+			r.OptionalBytesWrapper = proto.Clone(rhs).(*wrapperspb.BytesValue)
+		}
+	}
 	if rhs := m.RepeatedBoolWrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.BoolValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *wrapperspb.BoolValue }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.BoolValue)
+			}
 		}
 		r.RepeatedBoolWrapper = tmpContainer
 	}
 	if rhs := m.RepeatedInt32Wrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.Int32Value, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *wrapperspb.Int32Value }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.Int32Value)
+			}
 		}
 		r.RepeatedInt32Wrapper = tmpContainer
 	}
 	if rhs := m.RepeatedInt64Wrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.Int64Value, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *wrapperspb.Int64Value }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.Int64Value)
+			}
 		}
 		r.RepeatedInt64Wrapper = tmpContainer
 	}
 	if rhs := m.RepeatedUint32Wrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.UInt32Value, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value(v)
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *wrapperspb.UInt32Value
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.UInt32Value)
+			}
 		}
 		r.RepeatedUint32Wrapper = tmpContainer
 	}
 	if rhs := m.RepeatedUint64Wrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.UInt64Value, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value(v)
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *wrapperspb.UInt64Value
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.UInt64Value)
+			}
 		}
 		r.RepeatedUint64Wrapper = tmpContainer
 	}
 	if rhs := m.RepeatedFloatWrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.FloatValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *wrapperspb.FloatValue }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.FloatValue)
+			}
 		}
 		r.RepeatedFloatWrapper = tmpContainer
 	}
 	if rhs := m.RepeatedDoubleWrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.DoubleValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue(v)
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *wrapperspb.DoubleValue
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.DoubleValue)
+			}
 		}
 		r.RepeatedDoubleWrapper = tmpContainer
 	}
 	if rhs := m.RepeatedStringWrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.StringValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_StringValue(v)
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *wrapperspb.StringValue
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.StringValue)
+			}
 		}
 		r.RepeatedStringWrapper = tmpContainer
 	}
 	if rhs := m.RepeatedBytesWrapper; rhs != nil {
 		tmpContainer := make([]*wrapperspb.BytesValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *wrapperspb.BytesValue }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*wrapperspb.BytesValue)
+			}
 		}
 		r.RepeatedBytesWrapper = tmpContainer
+	}
+	if rhs := m.OptionalDuration; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *durationpb.Duration }); ok {
+			r.OptionalDuration = vtpb.CloneVT()
+		} else {
+			r.OptionalDuration = proto.Clone(rhs).(*durationpb.Duration)
+		}
+	}
+	if rhs := m.OptionalTimestamp; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *timestamppb.Timestamp }); ok {
+			r.OptionalTimestamp = vtpb.CloneVT()
+		} else {
+			r.OptionalTimestamp = proto.Clone(rhs).(*timestamppb.Timestamp)
+		}
+	}
+	if rhs := m.OptionalFieldMask; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *fieldmaskpb.FieldMask }); ok {
+			r.OptionalFieldMask = vtpb.CloneVT()
+		} else {
+			r.OptionalFieldMask = proto.Clone(rhs).(*fieldmaskpb.FieldMask)
+		}
+	}
+	if rhs := m.OptionalStruct; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *structpb.Struct }); ok {
+			r.OptionalStruct = vtpb.CloneVT()
+		} else {
+			r.OptionalStruct = proto.Clone(rhs).(*structpb.Struct)
+		}
+	}
+	if rhs := m.OptionalAny; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *anypb.Any }); ok {
+			r.OptionalAny = vtpb.CloneVT()
+		} else {
+			r.OptionalAny = proto.Clone(rhs).(*anypb.Any)
+		}
+	}
+	if rhs := m.OptionalValue; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *structpb.Value }); ok {
+			r.OptionalValue = vtpb.CloneVT()
+		} else {
+			r.OptionalValue = proto.Clone(rhs).(*structpb.Value)
+		}
 	}
 	if rhs := m.RepeatedDuration; rhs != nil {
 		tmpContainer := make([]*durationpb.Duration, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Duration(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *durationpb.Duration }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*durationpb.Duration)
+			}
 		}
 		r.RepeatedDuration = tmpContainer
 	}
 	if rhs := m.RepeatedTimestamp; rhs != nil {
 		tmpContainer := make([]*timestamppb.Timestamp, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *timestamppb.Timestamp }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*timestamppb.Timestamp)
+			}
 		}
 		r.RepeatedTimestamp = tmpContainer
 	}
 	if rhs := m.RepeatedFieldmask; rhs != nil {
 		tmpContainer := make([]*fieldmaskpb.FieldMask, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *fieldmaskpb.FieldMask }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*fieldmaskpb.FieldMask)
+			}
 		}
 		r.RepeatedFieldmask = tmpContainer
 	}
 	if rhs := m.RepeatedStruct; rhs != nil {
 		tmpContainer := make([]*structpb.Struct, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Struct(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *structpb.Struct }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*structpb.Struct)
+			}
 		}
 		r.RepeatedStruct = tmpContainer
 	}
 	if rhs := m.RepeatedAny; rhs != nil {
 		tmpContainer := make([]*anypb.Any, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Any(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *anypb.Any }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*anypb.Any)
+			}
 		}
 		r.RepeatedAny = tmpContainer
 	}
 	if rhs := m.RepeatedValue; rhs != nil {
 		tmpContainer := make([]*structpb.Value, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_Value(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *structpb.Value }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*structpb.Value)
+			}
 		}
 		r.RepeatedValue = tmpContainer
 	}
 	if rhs := m.RepeatedListValue; rhs != nil {
 		tmpContainer := make([]*structpb.ListValue, len(rhs))
 		for k, v := range rhs {
-			tmpContainer[k] = vt_clone_helper__test_messages_proto3__google_protobuf_ListValue(v)
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *structpb.ListValue }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*structpb.ListValue)
+			}
 		}
 		r.RepeatedListValue = tmpContainer
 	}
@@ -760,212 +929,6 @@ func (m *EnumOnlyProto3) CloneVT() *EnumOnlyProto3 {
 
 func (m *EnumOnlyProto3) CloneGenericVT() proto.Message {
 	return m.CloneVT()
-}
-
-var (
-	vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value  func(*wrapperspb.Int64Value) *wrapperspb.Int64Value
-	vt_clone_helper__test_messages_proto3__google_protobuf_StringValue func(*wrapperspb.StringValue) *wrapperspb.StringValue
-	vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp   func(*timestamppb.Timestamp) *timestamppb.Timestamp
-	vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask   func(*fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask
-	vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue  func(*wrapperspb.FloatValue) *wrapperspb.FloatValue
-	vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue func(*wrapperspb.DoubleValue) *wrapperspb.DoubleValue
-	vt_clone_helper__test_messages_proto3__google_protobuf_Any         func(*anypb.Any) *anypb.Any
-	vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue   func(*wrapperspb.BoolValue) *wrapperspb.BoolValue
-	vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value func(*wrapperspb.UInt64Value) *wrapperspb.UInt64Value
-	vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue  func(*wrapperspb.BytesValue) *wrapperspb.BytesValue
-	vt_clone_helper__test_messages_proto3__google_protobuf_Duration    func(*durationpb.Duration) *durationpb.Duration
-	vt_clone_helper__test_messages_proto3__google_protobuf_Struct      func(*structpb.Struct) *structpb.Struct
-	vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value  func(*wrapperspb.Int32Value) *wrapperspb.Int32Value
-	vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value func(*wrapperspb.UInt32Value) *wrapperspb.UInt32Value
-	vt_clone_helper__test_messages_proto3__google_protobuf_Value       func(*structpb.Value) *structpb.Value
-	vt_clone_helper__test_messages_proto3__google_protobuf_ListValue   func(*structpb.ListValue) *structpb.ListValue
-)
-
-func init() {
-	if _, ok := proto.Message((*wrapperspb.Int64Value)(nil)).(interface{ CloneVT() *wrapperspb.Int64Value }); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.Int64Value)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value = m.Func.Interface().(func(*wrapperspb.Int64Value) *wrapperspb.Int64Value)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Int64Value = func(m *wrapperspb.Int64Value) *wrapperspb.Int64Value {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.Int64Value)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.StringValue)(nil)).(interface {
-		CloneVT() *wrapperspb.StringValue
-	}); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.StringValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_StringValue = m.Func.Interface().(func(*wrapperspb.StringValue) *wrapperspb.StringValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_StringValue = func(m *wrapperspb.StringValue) *wrapperspb.StringValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.StringValue)
-		}
-	}
-	if _, ok := proto.Message((*timestamppb.Timestamp)(nil)).(interface{ CloneVT() *timestamppb.Timestamp }); ok {
-		m, _ := reflect.TypeOf((*timestamppb.Timestamp)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp = m.Func.Interface().(func(*timestamppb.Timestamp) *timestamppb.Timestamp)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Timestamp = func(m *timestamppb.Timestamp) *timestamppb.Timestamp {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*timestamppb.Timestamp)
-		}
-	}
-	if _, ok := proto.Message((*fieldmaskpb.FieldMask)(nil)).(interface{ CloneVT() *fieldmaskpb.FieldMask }); ok {
-		m, _ := reflect.TypeOf((*fieldmaskpb.FieldMask)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask = m.Func.Interface().(func(*fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_FieldMask = func(m *fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*fieldmaskpb.FieldMask)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.FloatValue)(nil)).(interface{ CloneVT() *wrapperspb.FloatValue }); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.FloatValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue = m.Func.Interface().(func(*wrapperspb.FloatValue) *wrapperspb.FloatValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_FloatValue = func(m *wrapperspb.FloatValue) *wrapperspb.FloatValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.FloatValue)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.DoubleValue)(nil)).(interface {
-		CloneVT() *wrapperspb.DoubleValue
-	}); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.DoubleValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue = m.Func.Interface().(func(*wrapperspb.DoubleValue) *wrapperspb.DoubleValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_DoubleValue = func(m *wrapperspb.DoubleValue) *wrapperspb.DoubleValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.DoubleValue)
-		}
-	}
-	if _, ok := proto.Message((*anypb.Any)(nil)).(interface{ CloneVT() *anypb.Any }); ok {
-		m, _ := reflect.TypeOf((*anypb.Any)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Any = m.Func.Interface().(func(*anypb.Any) *anypb.Any)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Any = func(m *anypb.Any) *anypb.Any {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*anypb.Any)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.BoolValue)(nil)).(interface{ CloneVT() *wrapperspb.BoolValue }); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.BoolValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue = m.Func.Interface().(func(*wrapperspb.BoolValue) *wrapperspb.BoolValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_BoolValue = func(m *wrapperspb.BoolValue) *wrapperspb.BoolValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.BoolValue)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.UInt64Value)(nil)).(interface {
-		CloneVT() *wrapperspb.UInt64Value
-	}); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.UInt64Value)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value = m.Func.Interface().(func(*wrapperspb.UInt64Value) *wrapperspb.UInt64Value)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_UInt64Value = func(m *wrapperspb.UInt64Value) *wrapperspb.UInt64Value {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.UInt64Value)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.BytesValue)(nil)).(interface{ CloneVT() *wrapperspb.BytesValue }); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.BytesValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue = m.Func.Interface().(func(*wrapperspb.BytesValue) *wrapperspb.BytesValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_BytesValue = func(m *wrapperspb.BytesValue) *wrapperspb.BytesValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.BytesValue)
-		}
-	}
-	if _, ok := proto.Message((*durationpb.Duration)(nil)).(interface{ CloneVT() *durationpb.Duration }); ok {
-		m, _ := reflect.TypeOf((*durationpb.Duration)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Duration = m.Func.Interface().(func(*durationpb.Duration) *durationpb.Duration)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Duration = func(m *durationpb.Duration) *durationpb.Duration {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*durationpb.Duration)
-		}
-	}
-	if _, ok := proto.Message((*structpb.Struct)(nil)).(interface{ CloneVT() *structpb.Struct }); ok {
-		m, _ := reflect.TypeOf((*structpb.Struct)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Struct = m.Func.Interface().(func(*structpb.Struct) *structpb.Struct)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Struct = func(m *structpb.Struct) *structpb.Struct {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*structpb.Struct)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.Int32Value)(nil)).(interface{ CloneVT() *wrapperspb.Int32Value }); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.Int32Value)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value = m.Func.Interface().(func(*wrapperspb.Int32Value) *wrapperspb.Int32Value)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Int32Value = func(m *wrapperspb.Int32Value) *wrapperspb.Int32Value {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.Int32Value)
-		}
-	}
-	if _, ok := proto.Message((*wrapperspb.UInt32Value)(nil)).(interface {
-		CloneVT() *wrapperspb.UInt32Value
-	}); ok {
-		m, _ := reflect.TypeOf((*wrapperspb.UInt32Value)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value = m.Func.Interface().(func(*wrapperspb.UInt32Value) *wrapperspb.UInt32Value)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_UInt32Value = func(m *wrapperspb.UInt32Value) *wrapperspb.UInt32Value {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*wrapperspb.UInt32Value)
-		}
-	}
-	if _, ok := proto.Message((*structpb.Value)(nil)).(interface{ CloneVT() *structpb.Value }); ok {
-		m, _ := reflect.TypeOf((*structpb.Value)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_Value = m.Func.Interface().(func(*structpb.Value) *structpb.Value)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_Value = func(m *structpb.Value) *structpb.Value {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*structpb.Value)
-		}
-	}
-	if _, ok := proto.Message((*structpb.ListValue)(nil)).(interface{ CloneVT() *structpb.ListValue }); ok {
-		m, _ := reflect.TypeOf((*structpb.ListValue)(nil)).MethodByName("CloneVT")
-		vt_clone_helper__test_messages_proto3__google_protobuf_ListValue = m.Func.Interface().(func(*structpb.ListValue) *structpb.ListValue)
-	} else {
-		vt_clone_helper__test_messages_proto3__google_protobuf_ListValue = func(m *structpb.ListValue) *structpb.ListValue {
-			if m == nil {
-				return nil
-			}
-			return proto.Clone(m).(*structpb.ListValue)
-		}
-	}
 }
 
 func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_NestedMessage) bool {

--- a/features/clone/clone.go
+++ b/features/clone/clone.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2021 PlanetScale Inc. All rights reserved.
+// Copyright (c) 2013, The GoGo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"github.com/planetscale/vtprotobuf/generator"
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const (
+	cloneName        = "CloneVT"
+	cloneGenericName = "CloneGenericVT"
+)
+
+var (
+	protoPkg   = protogen.GoImportPath("google.golang.org/protobuf/proto")
+	reflectPkg = protogen.GoImportPath("reflect")
+
+	nonAlphaNum = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
+
+func init() {
+	generator.RegisterFeature("clone", func(gen *generator.GeneratedFile) generator.FeatureGenerator {
+		return &clone{GeneratedFile: gen}
+	})
+}
+
+type clone struct {
+	*generator.GeneratedFile
+	once bool
+
+	// prefix allows to introduce dynamically named symbols without clashing with declarations in other
+	// generated files.
+	prefix string
+	// cloneHelperFuncNames tracks the message types for which clone helper functions are required, along
+	// with the name by which they are referenced.
+	cloneHelperFuncNames map[*protogen.Message]string
+}
+
+var _ generator.FeatureGenerator = (*clone)(nil)
+
+func (p *clone) Name() string {
+	return "clone"
+}
+
+func (p *clone) GenerateFile(file *protogen.File) bool {
+	proto3 := file.Desc.Syntax() == protoreflect.Proto3
+	p.prefix = nonAlphaNum.ReplaceAllString(strings.TrimSuffix(path.Base(file.Desc.Path()), ".proto"), "_")
+
+	for _, message := range file.Messages {
+		p.processMessage(proto3, message)
+	}
+
+	p.generateCloneHelperFuncs()
+
+	return p.once
+}
+
+func (p *clone) GenerateHelpers() {
+}
+
+// cloneOneofField generates the statements for cloning a oneof field
+func (p *clone) cloneOneofField(lhsBase, rhsBase string, oneof *protogen.Oneof) {
+	fieldname := oneof.GoName
+	ccInterfaceName := "is" + oneof.GoIdent.GoName
+	lhs := lhsBase + "." + fieldname
+	rhs := rhsBase + "." + fieldname
+	p.P(`if `, rhs, ` != nil {`)
+	p.P(lhs, ` = `, rhs, `.(interface{ `, cloneName, `() `, ccInterfaceName, ` }).`, cloneName, `()`)
+	p.P(`}`)
+}
+
+// cloneFieldSingular generates the code for cloning a singular, non-oneof field.
+func (p *clone) cloneFieldSingular(lhs, rhs string, kind protoreflect.Kind, message *protogen.Message) {
+	switch {
+	case kind == protoreflect.MessageKind, kind == protoreflect.GroupKind:
+		if p.IsLocalMessage(message) {
+			p.P(lhs, ` = `, rhs, `.`, cloneName, `()`)
+		} else {
+			cloneHelper := p.lookupCloneHelper(message)
+			p.P(lhs, ` = `, cloneHelper, `(`, rhs, `)`)
+		}
+	case kind == protoreflect.BytesKind:
+		p.P(`tmpBytes := make([]byte, len(`, rhs, `))`)
+		p.P(`copy(tmpBytes, `, rhs, `)`)
+		p.P(lhs, ` = tmpBytes`)
+	case isScalar(kind):
+		p.P(lhs, ` = `, rhs)
+	default:
+		panic("unexpected")
+	}
+}
+
+// cloneField generates the code for cloning a field in a protobuf.
+func (p *clone) cloneField(lhsBase, rhsBase string, allFieldsNullable bool, field *protogen.Field) {
+	// At this point, if we encounter a non-synthetic oneof, we assume it to be the representative
+	// field for that oneof.
+	if field.Oneof != nil && !field.Oneof.Desc.IsSynthetic() {
+		p.cloneOneofField(lhsBase, rhsBase, field.Oneof)
+		return
+	}
+
+	if !isReference(allFieldsNullable, field) {
+		panic("method should not be invoked for non-reference fields")
+	}
+
+	fieldname := field.GoName
+	lhs := lhsBase + "." + fieldname
+	rhs := rhsBase + "." + fieldname
+
+	// At this point, we are only looking at reference types (pointers, maps, slices, interfaces), which can all
+	// be nil.
+	p.P(`if rhs := `, rhs, `; rhs != nil {`)
+	rhs = "rhs"
+
+	fieldKind := field.Desc.Kind()
+	msg := field.Message // possibly nil
+
+	if field.Desc.Cardinality() == protoreflect.Repeated { // maps and slices
+		goType, _ := p.FieldGoType(field)
+		p.P(`tmpContainer := make(`, goType, `, len(`, rhs, `))`)
+		if isScalar(fieldKind) && field.Desc.IsList() {
+			// Generated code optimization: instead of iterating over all (key/index, value) pairs,
+			// do a single copy(dst, src) invocation for slices whose elements aren't reference types.
+			p.P(`copy(tmpContainer, `, rhs, `)`)
+		} else {
+			if field.Desc.IsMap() {
+				// For maps, the type of the value field determines what code is generated for cloning
+				// an entry.
+				valueField := field.Message.Fields[1]
+				fieldKind = valueField.Desc.Kind()
+				msg = valueField.Message
+			}
+			p.P(`for k, v := range `, rhs, ` {`)
+			p.cloneFieldSingular("tmpContainer[k]", "v", fieldKind, msg)
+			p.P(`}`)
+		}
+		p.P(lhs, ` = tmpContainer`)
+	} else if isScalar(fieldKind) {
+		p.P(`tmpVal := *`, rhs)
+		p.P(lhs, ` = &tmpVal`)
+	} else {
+		p.cloneFieldSingular(lhs, rhs, fieldKind, msg)
+	}
+	p.P(`}`)
+}
+
+func (p *clone) generateCloneMethodsForMessage(proto3 bool, message *protogen.Message) {
+	ccTypeName := message.GoIdent.GoName
+	p.P(`func (m *`, ccTypeName, `) `, cloneName, `() *`, ccTypeName, ` {`)
+	p.body(!proto3, ccTypeName, message.Fields)
+	p.P(`}`)
+	p.P()
+	p.P(`func (m *`, ccTypeName, `) `, cloneGenericName, `() `, protoPkg.Ident("Message"), ` {`)
+	p.P(`return m.`, cloneName, `()`)
+	p.P(`}`)
+	p.P()
+}
+
+// body generates the code for the actual cloning logic of a structure containing the given fields.
+// In practice, those can be the fields of a message, or of a oneof struct.
+// The object to be cloned is assumed to be called "m".
+func (p *clone) body(allFieldsNullable bool, ccTypeName string, fields []*protogen.Field) {
+	// The method body for a message or a oneof wrapper always starts with a nil check.
+	p.P(`if m == nil {`)
+	// We use an explicitly typed nil to avoid returning the nil interface in the oneof wrapper
+	// case.
+	p.P(`return (*`, ccTypeName, `)(nil)`)
+	p.P(`}`)
+
+	// Make a first pass over the fields, in which we initialize all non-reference fields via direct
+	// struct literal initialization, and extract all other (refernece) fields for a second pass.
+	p.P(`r := &`, ccTypeName, `{`)
+	var refFields []*protogen.Field
+	oneofFields := make(map[string]struct{}, len(fields))
+
+	for _, field := range fields {
+		if field.Oneof != nil && !field.Oneof.Desc.IsSynthetic() {
+			// Use the first field in a oneof as the representative for that oneof, disregard
+			// the other fields in that oneof.
+			if _, ok := oneofFields[field.Oneof.GoName]; !ok {
+				refFields = append(refFields, field)
+				oneofFields[field.Oneof.GoName] = struct{}{}
+			}
+			continue
+		}
+
+		if !isReference(allFieldsNullable, field) {
+			p.P(field.GoName, `: m.`, field.GoName, `,`)
+			continue
+		}
+		// Shortcut: for types where we know that an optimized clone method exists, we can call it directly as it is
+		// nil-safe.
+		if field.Desc.Cardinality() != protoreflect.Repeated && field.Message != nil {
+			if p.IsLocalMessage(field.Message) {
+				p.P(field.GoName, `: m.`, field.GoName, `.`, cloneName, `(),`)
+			} else {
+				cloneHelper := p.lookupCloneHelper(field.Message)
+				p.P(field.GoName, `: `, cloneHelper, `(m.`, field.GoName, `),`)
+			}
+			continue
+		}
+		refFields = append(refFields, field)
+	}
+	p.P(`}`)
+
+	// Generate explicit assignment statements for all reference fields.
+	for _, field := range refFields {
+		p.cloneField("r", "m", allFieldsNullable, field)
+	}
+
+	p.P(`return r`)
+}
+
+// generateCloneMethodsForOneof generates the clone method for the oneof wrapper type of a
+// field in a oneof.
+func (p *clone) generateCloneMethodsForOneof(field *protogen.Field) {
+	ccTypeName := field.GoIdent.GoName
+	ccInterfaceName := "is" + field.Oneof.GoIdent.GoName
+	p.P(`func (m *`, ccTypeName, `) `, cloneName, `() `, ccInterfaceName, ` {`)
+
+	// Create a "fake" field for the single oneof member, pretending it is not a oneof field.
+	fieldInOneof := *field
+	fieldInOneof.Oneof = nil
+	// If we have a scalar field in a oneof, that field is never nullable, even when using proto2
+	p.body(false, ccTypeName, []*protogen.Field{&fieldInOneof})
+	p.P(`}`)
+	p.P()
+}
+
+func (p *clone) processMessageOneofs(message *protogen.Message) {
+	for _, field := range message.Fields {
+		if field.Oneof == nil || field.Oneof.Desc.IsSynthetic() {
+			continue
+		}
+		p.generateCloneMethodsForOneof(field)
+	}
+}
+
+func (p *clone) processMessage(proto3 bool, message *protogen.Message) {
+	for _, nested := range message.Messages {
+		p.processMessage(proto3, nested)
+	}
+
+	if message.Desc.IsMapEntry() {
+		return
+	}
+
+	p.once = true
+
+	p.generateCloneMethodsForMessage(proto3, message)
+	p.processMessageOneofs(message)
+}
+
+// lookupCloneHelper retrieves the name of the helper function to clone a message of the given type,
+// and tracks the type for later code generation in generateCloneHelperFuncs.
+func (p *clone) lookupCloneHelper(message *protogen.Message) string {
+	helperName := p.cloneHelperFuncNames[message]
+	if helperName == "" {
+		if p.cloneHelperFuncNames == nil {
+			p.cloneHelperFuncNames = make(map[*protogen.Message]string)
+		}
+		helperName = "vt_clone_helper__" + p.prefix + "__" + nonAlphaNum.ReplaceAllString(string(message.Desc.FullName()), "_")
+		p.cloneHelperFuncNames[message] = helperName
+	}
+	return helperName
+}
+
+// generateCloneHelperFuncs introduces function-typed variables for cloning non-local messages.
+// These variables either point to the CloneVT method, if one exists for the type, or a wrapper using
+// proto.Clone and a cast.
+func (p *clone) generateCloneHelperFuncs() {
+	if len(p.cloneHelperFuncNames) == 0 {
+		return
+	}
+	p.P(`var (`)
+	for msg, helperName := range p.cloneHelperFuncNames {
+		ccTypeName := p.QualifiedGoIdent(msg.GoIdent)
+		p.P(helperName, ` func(*`, ccTypeName, `) *`, ccTypeName)
+	}
+	p.P(`)`)
+	p.P()
+	p.P(`func init() {`)
+	for msg, helperName := range p.cloneHelperFuncNames {
+		ccTypeName := p.QualifiedGoIdent(msg.GoIdent)
+		// Use interface type assertions + reflection _once_ to retrieve the typed CloneVT func.
+		p.P(`if _, ok := `, protoPkg.Ident("Message"), `((*`, ccTypeName, `)(nil)).(interface{ `, cloneName, `() *`, ccTypeName, ` }); ok {`)
+		p.P(`m, _ := `, reflectPkg.Ident("TypeOf"), `((*`, ccTypeName, `)(nil)).MethodByName("`, cloneName, `")`)
+		p.P(helperName, ` = m.Func.Interface().(func(*`, ccTypeName, `) *`, ccTypeName, `)`)
+		p.P(`} else {`)
+		p.P(helperName, ` = func(m *`, ccTypeName, `) *`, ccTypeName, ` {`)
+		p.P(`if m == nil {`)
+		p.P(`return nil`)
+		p.P(`}`)
+		p.P(`return `, protoPkg.Ident("Clone"), `(m).(*`, ccTypeName, `)`)
+		p.P(`}`)
+		p.P(`}`)
+	}
+	p.P(`}`)
+	p.P()
+}
+
+// isReference checks whether the Go equivalent of the given field is of reference type, i.e., can be nil.
+func isReference(allFieldsNullable bool, field *protogen.Field) bool {
+	if allFieldsNullable || field.Oneof != nil || field.Message != nil || field.Desc.Cardinality() == protoreflect.Repeated || field.Desc.Kind() == protoreflect.BytesKind {
+		return true
+	}
+	if !isScalar(field.Desc.Kind()) {
+		panic("unexpected non-reference, non-scalar field")
+	}
+	return false
+}
+
+func isScalar(kind protoreflect.Kind) bool {
+	switch kind {
+	case
+		protoreflect.BoolKind,
+		protoreflect.StringKind,
+		protoreflect.DoubleKind, protoreflect.Fixed64Kind, protoreflect.Sfixed64Kind,
+		protoreflect.FloatKind, protoreflect.Fixed32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Int64Kind, protoreflect.Uint64Kind, protoreflect.Sint64Kind,
+		protoreflect.Int32Kind, protoreflect.Uint32Kind, protoreflect.Sint32Kind,
+		protoreflect.EnumKind:
+		return true
+	}
+	return false
+}

--- a/features/clone/clone.go
+++ b/features/clone/clone.go
@@ -6,12 +6,14 @@
 package clone
 
 import (
-	"github.com/planetscale/vtprotobuf/generator"
-	"google.golang.org/protobuf/compiler/protogen"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/planetscale/vtprotobuf/generator"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -6,6 +6,7 @@ package pool
 
 import (
 	fmt "fmt"
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	bits "math/bits"
@@ -18,6 +19,21 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *MemoryPoolExtension) CloneVT() *MemoryPoolExtension {
+	if m == nil {
+		return (*MemoryPoolExtension)(nil)
+	}
+	r := &MemoryPoolExtension{
+		Foo1: m.Foo1,
+		Foo2: m.Foo2,
+	}
+	return r
+}
+
+func (m *MemoryPoolExtension) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
 	if this == nil {

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -6,6 +6,7 @@ package pool
 
 import (
 	fmt "fmt"
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	sync "sync"
@@ -17,6 +18,88 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *Test1) CloneVT() *Test1 {
+	if m == nil {
+		return (*Test1)(nil)
+	}
+	r := &Test1{}
+	if rhs := m.Sl; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Sl = tmpContainer
+	}
+	return r
+}
+
+func (m *Test1) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Test2) CloneVT() *Test2 {
+	if m == nil {
+		return (*Test2)(nil)
+	}
+	r := &Test2{}
+	if rhs := m.Sl; rhs != nil {
+		tmpContainer := make([]*Slice2, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Sl = tmpContainer
+	}
+	return r
+}
+
+func (m *Test2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Slice2) CloneVT() *Slice2 {
+	if m == nil {
+		return (*Slice2)(nil)
+	}
+	r := &Slice2{
+		D: m.D.CloneVT(),
+		E: m.E,
+		F: m.F,
+	}
+	if rhs := m.A; rhs != nil {
+		tmpContainer := make(map[int64]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.A = tmpContainer
+	}
+	if rhs := m.B; rhs != nil {
+		tmpVal := *rhs
+		r.B = &tmpVal
+	}
+	if rhs := m.C; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.C = tmpContainer
+	}
+	return r
+}
+
+func (m *Slice2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Element2) CloneVT() *Element2 {
+	if m == nil {
+		return (*Element2)(nil)
+	}
+	r := &Element2{
+		A: m.A,
+	}
+	return r
+}
+
+func (m *Element2) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (this *Test1) EqualVT(that *Test1) bool {
 	if this == nil {

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -7,6 +7,7 @@ package proto2
 import (
 	binary "encoding/binary"
 	fmt "fmt"
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	math "math"
@@ -19,6 +20,482 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *DoubleMessage) CloneVT() *DoubleMessage {
+	if m == nil {
+		return (*DoubleMessage)(nil)
+	}
+	r := &DoubleMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *DoubleMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *FloatMessage) CloneVT() *FloatMessage {
+	if m == nil {
+		return (*FloatMessage)(nil)
+	}
+	r := &FloatMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]float32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *FloatMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Int32Message) CloneVT() *Int32Message {
+	if m == nil {
+		return (*Int32Message)(nil)
+	}
+	r := &Int32Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Int32Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Int64Message) CloneVT() *Int64Message {
+	if m == nil {
+		return (*Int64Message)(nil)
+	}
+	r := &Int64Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Int64Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Uint32Message) CloneVT() *Uint32Message {
+	if m == nil {
+		return (*Uint32Message)(nil)
+	}
+	r := &Uint32Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Uint32Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Uint64Message) CloneVT() *Uint64Message {
+	if m == nil {
+		return (*Uint64Message)(nil)
+	}
+	r := &Uint64Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Uint64Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Sint32Message) CloneVT() *Sint32Message {
+	if m == nil {
+		return (*Sint32Message)(nil)
+	}
+	r := &Sint32Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Sint32Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Sint64Message) CloneVT() *Sint64Message {
+	if m == nil {
+		return (*Sint64Message)(nil)
+	}
+	r := &Sint64Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Sint64Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Fixed32Message) CloneVT() *Fixed32Message {
+	if m == nil {
+		return (*Fixed32Message)(nil)
+	}
+	r := &Fixed32Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Fixed32Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Fixed64Message) CloneVT() *Fixed64Message {
+	if m == nil {
+		return (*Fixed64Message)(nil)
+	}
+	r := &Fixed64Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Fixed64Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Sfixed32Message) CloneVT() *Sfixed32Message {
+	if m == nil {
+		return (*Sfixed32Message)(nil)
+	}
+	r := &Sfixed32Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Sfixed32Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Sfixed64Message) CloneVT() *Sfixed64Message {
+	if m == nil {
+		return (*Sfixed64Message)(nil)
+	}
+	r := &Sfixed64Message{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *Sfixed64Message) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *BoolMessage) CloneVT() *BoolMessage {
+	if m == nil {
+		return (*BoolMessage)(nil)
+	}
+	r := &BoolMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]bool, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *BoolMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *StringMessage) CloneVT() *StringMessage {
+	if m == nil {
+		return (*StringMessage)(nil)
+	}
+	r := &StringMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	return r
+}
+
+func (m *StringMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *BytesMessage) CloneVT() *BytesMessage {
+	if m == nil {
+		return (*BytesMessage)(nil)
+	}
+	r := &BytesMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.RequiredField = tmpBytes
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OptionalField = tmpBytes
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.RepeatedField = tmpContainer
+	}
+	return r
+}
+
+func (m *BytesMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *EnumMessage) CloneVT() *EnumMessage {
+	if m == nil {
+		return (*EnumMessage)(nil)
+	}
+	r := &EnumMessage{}
+	if rhs := m.RequiredField; rhs != nil {
+		tmpVal := *rhs
+		r.RequiredField = &tmpVal
+	}
+	if rhs := m.OptionalField; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalField = &tmpVal
+	}
+	if rhs := m.RepeatedField; rhs != nil {
+		tmpContainer := make([]EnumMessage_Num, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RepeatedField = tmpContainer
+	}
+	if rhs := m.PackedField; rhs != nil {
+		tmpContainer := make([]EnumMessage_Num, len(rhs))
+		copy(tmpContainer, rhs)
+		r.PackedField = tmpContainer
+	}
+	return r
+}
+
+func (m *EnumMessage) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (this *DoubleMessage) EqualVT(that *DoubleMessage) bool {
 	if this == nil {

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -7,6 +7,7 @@ package proto3opt
 import (
 	binary "encoding/binary"
 	fmt "fmt"
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	math "math"
@@ -19,6 +20,83 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *OptionalFieldInProto3) CloneVT() *OptionalFieldInProto3 {
+	if m == nil {
+		return (*OptionalFieldInProto3)(nil)
+	}
+	r := &OptionalFieldInProto3{}
+	if rhs := m.OptionalInt32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalInt32 = &tmpVal
+	}
+	if rhs := m.OptionalInt64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalInt64 = &tmpVal
+	}
+	if rhs := m.OptionalUint32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalUint32 = &tmpVal
+	}
+	if rhs := m.OptionalUint64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalUint64 = &tmpVal
+	}
+	if rhs := m.OptionalSint32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSint32 = &tmpVal
+	}
+	if rhs := m.OptionalSint64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSint64 = &tmpVal
+	}
+	if rhs := m.OptionalFixed32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFixed32 = &tmpVal
+	}
+	if rhs := m.OptionalFixed64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFixed64 = &tmpVal
+	}
+	if rhs := m.OptionalSfixed32; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSfixed32 = &tmpVal
+	}
+	if rhs := m.OptionalSfixed64; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalSfixed64 = &tmpVal
+	}
+	if rhs := m.OptionalFloat; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalFloat = &tmpVal
+	}
+	if rhs := m.OptionalDouble; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalDouble = &tmpVal
+	}
+	if rhs := m.OptionalBool; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalBool = &tmpVal
+	}
+	if rhs := m.OptionalString; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalString = &tmpVal
+	}
+	if rhs := m.OptionalBytes; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OptionalBytes = tmpBytes
+	}
+	if rhs := m.OptionalEnum; rhs != nil {
+		tmpVal := *rhs
+		r.OptionalEnum = &tmpVal
+	}
+	return r
+}
+
+func (m *OptionalFieldInProto3) CloneGenericVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (this *OptionalFieldInProto3) EqualVT(that *OptionalFieldInProto3) bool {
 	if this == nil {


### PR DESCRIPTION
This adds a new `clone` option to the generator that, when enabled, generates the following optimized methods for each message type:
- `func (p *YourProto) CloneVT() *YourProto`, which returns a cloned message, i.e., the resulting message is equal to `p` but does not share any memory.
- `func (p *YourProto) CloneGenericVT() proto.Message`, which does the same as the above, with the benefit of offering a type-independent signature such that it can be invoked via an interface type assertion on any `proto.Message` (in a dynamic setting where the type is not known at compile time, `CloneVT` can only be accessed via reflection/`MethodByName`)

Fixes #45. (actually, just one half, I can easily add the `CopyVT` logic if this is desired)
