### PR TITLE
equal: fix bug confusing zero and unset oneof values

### DIFF
--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -245,16 +245,9 @@ func (this *ConformanceRequest) EqualVT(that *ConformanceRequest) bool {
 		if that.Payload == nil {
 			return false
 		}
-		if string(this.GetProtobufPayload()) != string(that.GetProtobufPayload()) {
-			return false
-		}
-		if this.GetJsonPayload() != that.GetJsonPayload() {
-			return false
-		}
-		if this.GetJspbPayload() != that.GetJspbPayload() {
-			return false
-		}
-		if this.GetTextPayload() != that.GetTextPayload() {
+		if !this.Payload.(interface {
+			EqualVT(isConformanceRequest_Payload) bool
+		}).EqualVT(that.Payload) {
 			return false
 		}
 	}
@@ -276,6 +269,74 @@ func (this *ConformanceRequest) EqualVT(that *ConformanceRequest) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *ConformanceRequest_ProtobufPayload) EqualVT(thatIface isConformanceRequest_Payload) bool {
+	that, ok := thatIface.(*ConformanceRequest_ProtobufPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if string(this.ProtobufPayload) != string(that.ProtobufPayload) {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceRequest_JsonPayload) EqualVT(thatIface isConformanceRequest_Payload) bool {
+	that, ok := thatIface.(*ConformanceRequest_JsonPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.JsonPayload != that.JsonPayload {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceRequest_JspbPayload) EqualVT(thatIface isConformanceRequest_Payload) bool {
+	that, ok := thatIface.(*ConformanceRequest_JspbPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.JspbPayload != that.JspbPayload {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceRequest_TextPayload) EqualVT(thatIface isConformanceRequest_Payload) bool {
+	that, ok := thatIface.(*ConformanceRequest_TextPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.TextPayload != that.TextPayload {
+		return false
+	}
+	return true
+}
+
 func (this *ConformanceResponse) EqualVT(that *ConformanceResponse) bool {
 	if this == nil {
 		return that == nil || that.String() == ""
@@ -288,32 +349,149 @@ func (this *ConformanceResponse) EqualVT(that *ConformanceResponse) bool {
 		if that.Result == nil {
 			return false
 		}
-		if this.GetParseError() != that.GetParseError() {
-			return false
-		}
-		if this.GetRuntimeError() != that.GetRuntimeError() {
-			return false
-		}
-		if string(this.GetProtobufPayload()) != string(that.GetProtobufPayload()) {
-			return false
-		}
-		if this.GetJsonPayload() != that.GetJsonPayload() {
-			return false
-		}
-		if this.GetSkipped() != that.GetSkipped() {
-			return false
-		}
-		if this.GetSerializeError() != that.GetSerializeError() {
-			return false
-		}
-		if this.GetJspbPayload() != that.GetJspbPayload() {
-			return false
-		}
-		if this.GetTextPayload() != that.GetTextPayload() {
+		if !this.Result.(interface {
+			EqualVT(isConformanceResponse_Result) bool
+		}).EqualVT(that.Result) {
 			return false
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ConformanceResponse_ParseError) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_ParseError)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.ParseError != that.ParseError {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_RuntimeError) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_RuntimeError)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.RuntimeError != that.RuntimeError {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_ProtobufPayload) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_ProtobufPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if string(this.ProtobufPayload) != string(that.ProtobufPayload) {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_JsonPayload) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_JsonPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.JsonPayload != that.JsonPayload {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_Skipped) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_Skipped)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.Skipped != that.Skipped {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_SerializeError) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_SerializeError)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.SerializeError != that.SerializeError {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_JspbPayload) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_JspbPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.JspbPayload != that.JspbPayload {
+		return false
+	}
+	return true
+}
+
+func (this *ConformanceResponse_TextPayload) EqualVT(thatIface isConformanceResponse_Result) bool {
+	that, ok := thatIface.(*ConformanceResponse_TextPayload)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.TextPayload != that.TextPayload {
+		return false
+	}
+	return true
 }
 
 func (this *JspbEncodingConfig) EqualVT(that *JspbEncodingConfig) bool {

--- a/conformance/internal/conformance/equalvt_test.go
+++ b/conformance/internal/conformance/equalvt_test.go
@@ -192,3 +192,27 @@ func TestEqualVT_Map_AbsenceVsZeroValue(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestEqualVT_Oneof_AbsenceVsZeroValue(t *testing.T) {
+	a := &TestAllTypesProto3{
+		OneofField: &TestAllTypesProto3_OneofUint32{
+			OneofUint32: 0,
+		},
+	}
+	b := &TestAllTypesProto3{
+		OneofField: &TestAllTypesProto3_OneofString{
+			OneofString: "",
+		},
+	}
+
+	aJson, err := protojson.Marshal(a)
+	require.NoError(t, err)
+	bJson, err := protojson.Marshal(b)
+	require.NoError(t, err)
+
+	if a.EqualVT(b) {
+		assert.JSONEq(t, string(aJson), string(bJson))
+		err := fmt.Errorf("these %T should not be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
+		require.NoError(t, err)
+	}
+}

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -995,31 +995,9 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 		if that.OneofField == nil {
 			return false
 		}
-		if this.GetOneofUint32() != that.GetOneofUint32() {
-			return false
-		}
-		if !this.GetOneofNestedMessage().EqualVT(that.GetOneofNestedMessage()) {
-			return false
-		}
-		if this.GetOneofString() != that.GetOneofString() {
-			return false
-		}
-		if string(this.GetOneofBytes()) != string(that.GetOneofBytes()) {
-			return false
-		}
-		if this.GetOneofBool() != that.GetOneofBool() {
-			return false
-		}
-		if this.GetOneofUint64() != that.GetOneofUint64() {
-			return false
-		}
-		if this.GetOneofFloat() != that.GetOneofFloat() {
-			return false
-		}
-		if this.GetOneofDouble() != that.GetOneofDouble() {
-			return false
-		}
-		if this.GetOneofEnum() != that.GetOneofEnum() {
+		if !this.OneofField.(interface {
+			EqualVT(isTestAllTypesProto2_OneofField) bool
+		}).EqualVT(that.OneofField) {
 			return false
 		}
 	}
@@ -1861,6 +1839,159 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *TestAllTypesProto2_OneofUint32) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofUint32)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofUint32 != that.OneofUint32 {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofNestedMessage) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofNestedMessage)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if !this.OneofNestedMessage.EqualVT(that.OneofNestedMessage) {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofString) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofString)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofString != that.OneofString {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofBytes) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofBytes)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if string(this.OneofBytes) != string(that.OneofBytes) {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofBool) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofBool)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofBool != that.OneofBool {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofUint64) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofUint64)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofUint64 != that.OneofUint64 {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofFloat) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofFloat)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofFloat != that.OneofFloat {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofDouble) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofDouble)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofDouble != that.OneofDouble {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto2_OneofEnum) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto2_OneofEnum)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofEnum != that.OneofEnum {
+		return false
+	}
+	return true
 }
 
 func (this *ForeignMessageProto2) EqualVT(that *ForeignMessageProto2) bool {

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -958,34 +958,9 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 		if that.OneofField == nil {
 			return false
 		}
-		if this.GetOneofUint32() != that.GetOneofUint32() {
-			return false
-		}
-		if !this.GetOneofNestedMessage().EqualVT(that.GetOneofNestedMessage()) {
-			return false
-		}
-		if this.GetOneofString() != that.GetOneofString() {
-			return false
-		}
-		if string(this.GetOneofBytes()) != string(that.GetOneofBytes()) {
-			return false
-		}
-		if this.GetOneofBool() != that.GetOneofBool() {
-			return false
-		}
-		if this.GetOneofUint64() != that.GetOneofUint64() {
-			return false
-		}
-		if this.GetOneofFloat() != that.GetOneofFloat() {
-			return false
-		}
-		if this.GetOneofDouble() != that.GetOneofDouble() {
-			return false
-		}
-		if this.GetOneofEnum() != that.GetOneofEnum() {
-			return false
-		}
-		if this.GetOneofNullValue() != that.GetOneofNullValue() {
+		if !this.OneofField.(interface {
+			EqualVT(isTestAllTypesProto3_OneofField) bool
+		}).EqualVT(that.OneofField) {
 			return false
 		}
 	}
@@ -2148,6 +2123,176 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *TestAllTypesProto3_OneofUint32) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofUint32)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofUint32 != that.OneofUint32 {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofNestedMessage) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofNestedMessage)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if !this.OneofNestedMessage.EqualVT(that.OneofNestedMessage) {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofString) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofString)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofString != that.OneofString {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofBytes) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofBytes)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if string(this.OneofBytes) != string(that.OneofBytes) {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofBool) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofBool)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofBool != that.OneofBool {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofUint64) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofUint64)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofUint64 != that.OneofUint64 {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofFloat) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofFloat)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofFloat != that.OneofFloat {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofDouble) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofDouble)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofDouble != that.OneofDouble {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofEnum) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofEnum)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofEnum != that.OneofEnum {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3_OneofNullValue) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
+	that, ok := thatIface.(*TestAllTypesProto3_OneofNullValue)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.OneofNullValue != that.OneofNullValue {
+		return false
+	}
+	return true
 }
 
 func (this *ForeignMessage) EqualVT(that *ForeignMessage) bool {

--- a/features/equal/equal.go
+++ b/features/equal/equal.go
@@ -106,11 +106,11 @@ func (p *equal) message(proto3 bool, message *protogen.Message) {
 		if !oneof {
 			continue
 		}
-		p.oneof(field, false)
+		p.oneof(field)
 	}
 }
 
-func (p *equal) oneof(field *protogen.Field, nullable bool) {
+func (p *equal) oneof(field *protogen.Field) {
 	ccTypeName := field.GoIdent.GoName
 	ccInterfaceName := fmt.Sprintf("is%s", field.Oneof.GoIdent.GoName)
 	fieldname := field.GoName
@@ -132,7 +132,7 @@ func (p *equal) oneof(field *protogen.Field, nullable bool) {
 	kind := field.Desc.Kind()
 	switch {
 	case isScalar(kind):
-		p.compareScalar(lhs, rhs, nullable)
+		p.compareScalar(lhs, rhs, false)
 	case kind == protoreflect.BytesKind:
 		p.compareBytes(lhs, rhs)
 	case kind == protoreflect.MessageKind || kind == protoreflect.GroupKind:


### PR DESCRIPTION
Change the code generation to compare the actual types of oneof wrapper fields and ensure they are equal, rather than looking at the (potentially zero) values of the fields under the oneof (which could be either explicitly set or unset).

Fixes #50 .