### PR TITLE
equal: Generate presence checks for bytes fields, where necessary

### DIFF
--- a/conformance/internal/conformance/equalvt_test.go
+++ b/conformance/internal/conformance/equalvt_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/planetscale/vtprotobuf/testproto/proto3opt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -212,6 +213,96 @@ func TestEqualVT_Oneof_AbsenceVsZeroValue(t *testing.T) {
 
 	if a.EqualVT(b) {
 		assert.JSONEq(t, string(aJson), string(bJson))
+		err := fmt.Errorf("these %T should not be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
+		require.NoError(t, err)
+	}
+}
+
+func TestEqualVT_Proto2_BytesPresence(t *testing.T) {
+	a := &TestAllTypesProto2{
+		OptionalBytes: nil,
+	}
+	b := &TestAllTypesProto2{
+		OptionalBytes: []byte{},
+	}
+
+	require.False(t, proto.Equal(a, b))
+
+	aJson, err := protojson.Marshal(a)
+	require.NoError(t, err)
+	bJson, err := protojson.Marshal(b)
+	require.NoError(t, err)
+
+	if a.EqualVT(b) {
+		assert.JSONEq(t, string(aJson), string(bJson))
+		err := fmt.Errorf("these %T should not be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
+		require.NoError(t, err)
+	}
+}
+
+func TestEqualVT_Proto3_BytesPresence(t *testing.T) {
+	a := &proto3opt.OptionalFieldInProto3{
+		OptionalBytes: nil,
+	}
+	b := &proto3opt.OptionalFieldInProto3{
+		OptionalBytes: []byte{},
+	}
+
+	require.False(t, proto.Equal(a, b))
+
+	aJson, err := protojson.Marshal(a)
+	require.NoError(t, err)
+	bJson, err := protojson.Marshal(b)
+	require.NoError(t, err)
+
+	if a.EqualVT(b) {
+		assert.JSONEq(t, string(aJson), string(bJson))
+		err := fmt.Errorf("these %T should not be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
+		require.NoError(t, err)
+	}
+}
+
+func TestEqualVT_Proto2_BytesNoPresence(t *testing.T) {
+	a := &TestAllTypesProto2{
+		RepeatedBytes: [][]byte{nil},
+		OneofField: &TestAllTypesProto2_OneofBytes{
+			OneofBytes: nil,
+		},
+	}
+	b := &TestAllTypesProto2{
+		RepeatedBytes: [][]byte{{}},
+		OneofField: &TestAllTypesProto2_OneofBytes{
+			OneofBytes: []byte{},
+		},
+	}
+
+	require.True(t, proto.Equal(a, b))
+
+	if !a.EqualVT(b) {
+		err := fmt.Errorf("these %T should be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
+		require.NoError(t, err)
+	}
+}
+
+func TestEqualVT_Proto3_BytesNoPresence(t *testing.T) {
+	a := &TestAllTypesProto3{
+		RepeatedBytes: [][]byte{nil},
+		OneofField: &TestAllTypesProto3_OneofBytes{
+			OneofBytes: nil,
+		},
+		OptionalBytes: nil,
+	}
+	b := &TestAllTypesProto3{
+		RepeatedBytes: [][]byte{{}},
+		OneofField: &TestAllTypesProto3_OneofBytes{
+			OneofBytes: []byte{},
+		},
+		OptionalBytes: []byte{},
+	}
+
+	require.True(t, proto.Equal(a, b))
+
+	if !a.EqualVT(b) {
 		err := fmt.Errorf("these %T should not be equal:\nmsg = %+v\noriginal = %+v", a, a, b)
 		require.NoError(t, err)
 	}

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -1043,7 +1043,7 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	if p, q := this.OptionalString, that.OptionalString; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
-	if string(this.OptionalBytes) != string(that.OptionalBytes) {
+	if p, q := this.OptionalBytes, that.OptionalBytes; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
 	}
 	if !this.OptionalNestedMessage.EqualVT(that.OptionalNestedMessage) {
@@ -1781,7 +1781,7 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	if p, q := this.DefaultString, that.DefaultString; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
-	if string(this.DefaultBytes) != string(that.DefaultBytes) {
+	if p, q := this.DefaultBytes, that.DefaultBytes; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
 	}
 	if p, q := this.Fieldname1, that.Fieldname1; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -956,10 +956,10 @@ func (this *BytesMessage) EqualVT(that *BytesMessage) bool {
 	} else if that == nil {
 		return this.String() == ""
 	}
-	if string(this.RequiredField) != string(that.RequiredField) {
+	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
 	}
-	if string(this.OptionalField) != string(that.OptionalField) {
+	if p, q := this.OptionalField, that.OptionalField; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
 	}
 	if len(this.RepeatedField) != len(that.RepeatedField) {

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -146,7 +146,7 @@ func (this *OptionalFieldInProto3) EqualVT(that *OptionalFieldInProto3) bool {
 	if p, q := this.OptionalString, that.OptionalString; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
-	if string(this.OptionalBytes) != string(that.OptionalBytes) {
+	if p, q := this.OptionalBytes, that.OptionalBytes; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
 	}
 	if p, q := this.OptionalEnum, that.OptionalEnum; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {


### PR DESCRIPTION
Updates the `equal` code generation to correctly generate presence checks for `bytes` fields where necessary, by distinguishing `[]byte(nil)` from `[]byte{}`. See #52 for a more detailed description.

Fixes #52 .