### PR TITLE
clone: Take unknown fields into account

### DIFF
--- a/conformance/internal/conformance/clonevt_test.go
+++ b/conformance/internal/conformance/clonevt_test.go
@@ -2,11 +2,11 @@ package conformance
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/encoding/protowire"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"

--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -28,6 +28,10 @@ func (m *FailureSet) CloneVT() *FailureSet {
 		copy(tmpContainer, rhs)
 		r.Failure = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -50,6 +54,10 @@ func (m *ConformanceRequest) CloneVT() *ConformanceRequest {
 		r.Payload = m.Payload.(interface {
 			CloneVT() isConformanceRequest_Payload
 		}).CloneVT()
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -110,6 +118,10 @@ func (m *ConformanceResponse) CloneVT() *ConformanceResponse {
 		r.Result = m.Result.(interface {
 			CloneVT() isConformanceResponse_Result
 		}).CloneVT()
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -207,6 +219,10 @@ func (m *JspbEncodingConfig) CloneVT() *JspbEncodingConfig {
 	}
 	r := &JspbEncodingConfig{
 		UseJspbArrayAnyFormat: m.UseJspbArrayAnyFormat,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -32,6 +32,10 @@ func (m *TestAllTypesProto2_NestedMessage) CloneVT() *TestAllTypesProto2_NestedM
 		tmpVal := *rhs
 		r.A = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -52,6 +56,10 @@ func (m *TestAllTypesProto2_Data) CloneVT() *TestAllTypesProto2_Data {
 		tmpVal := *rhs
 		r.GroupUint32 = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -64,6 +72,10 @@ func (m *TestAllTypesProto2_MessageSetCorrect) CloneVT() *TestAllTypesProto2_Mes
 		return (*TestAllTypesProto2_MessageSetCorrect)(nil)
 	}
 	r := &TestAllTypesProto2_MessageSetCorrect{}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -80,6 +92,10 @@ func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneVT() *TestAllTypes
 		tmpVal := *rhs
 		r.Str = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -95,6 +111,10 @@ func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneVT() *TestAllTypes
 	if rhs := m.I; rhs != nil {
 		tmpVal := *rhs
 		r.I = &tmpVal
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -716,6 +736,10 @@ func (m *TestAllTypesProto2) CloneVT() *TestAllTypesProto2 {
 		tmpVal := *rhs
 		r.FieldName18__ = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -825,6 +849,10 @@ func (m *ForeignMessageProto2) CloneVT() *ForeignMessageProto2 {
 		tmpVal := *rhs
 		r.C = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -840,6 +868,10 @@ func (m *UnknownToTestAllTypes_OptionalGroup) CloneVT() *UnknownToTestAllTypes_O
 	if rhs := m.A; rhs != nil {
 		tmpVal := *rhs
 		r.A = &tmpVal
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -873,6 +905,10 @@ func (m *UnknownToTestAllTypes) CloneVT() *UnknownToTestAllTypes {
 		copy(tmpContainer, rhs)
 		r.RepeatedInt32 = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -885,6 +921,10 @@ func (m *NullHypothesisProto2) CloneVT() *NullHypothesisProto2 {
 		return (*NullHypothesisProto2)(nil)
 	}
 	r := &NullHypothesisProto2{}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -897,6 +937,10 @@ func (m *EnumOnlyProto2) CloneVT() *EnumOnlyProto2 {
 		return (*EnumOnlyProto2)(nil)
 	}
 	r := &EnumOnlyProto2{}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -912,6 +956,10 @@ func (m *OneStringProto2) CloneVT() *OneStringProto2 {
 	if rhs := m.Data; rhs != nil {
 		tmpVal := *rhs
 		r.Data = &tmpVal
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -34,6 +34,10 @@ func (m *TestAllTypesProto3_NestedMessage) CloneVT() *TestAllTypesProto3_NestedM
 		A:           m.A,
 		Corecursive: m.Corecursive.CloneVT(),
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -783,6 +787,10 @@ func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
 		}
 		r.RepeatedListValue = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -900,6 +908,10 @@ func (m *ForeignMessage) CloneVT() *ForeignMessage {
 	r := &ForeignMessage{
 		C: m.C,
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -912,6 +924,10 @@ func (m *NullHypothesisProto3) CloneVT() *NullHypothesisProto3 {
 		return (*NullHypothesisProto3)(nil)
 	}
 	r := &NullHypothesisProto3{}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -924,6 +940,10 @@ func (m *EnumOnlyProto3) CloneVT() *EnumOnlyProto3 {
 		return (*EnumOnlyProto3)(nil)
 	}
 	r := &EnumOnlyProto3{}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -28,6 +28,10 @@ func (m *MemoryPoolExtension) CloneVT() *MemoryPoolExtension {
 		Foo1: m.Foo1,
 		Foo2: m.Foo2,
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -29,6 +29,10 @@ func (m *Test1) CloneVT() *Test1 {
 		copy(tmpContainer, rhs)
 		r.Sl = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -47,6 +51,10 @@ func (m *Test2) CloneVT() *Test2 {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Sl = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -80,6 +88,10 @@ func (m *Slice2) CloneVT() *Slice2 {
 		copy(tmpContainer, rhs)
 		r.C = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -93,6 +105,10 @@ func (m *Element2) CloneVT() *Element2 {
 	}
 	r := &Element2{
 		A: m.A,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -44,6 +44,10 @@ func (m *DoubleMessage) CloneVT() *DoubleMessage {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -73,6 +77,10 @@ func (m *FloatMessage) CloneVT() *FloatMessage {
 		tmpContainer := make([]float32, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -104,6 +112,10 @@ func (m *Int32Message) CloneVT() *Int32Message {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -133,6 +145,10 @@ func (m *Int64Message) CloneVT() *Int64Message {
 		tmpContainer := make([]int64, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -164,6 +180,10 @@ func (m *Uint32Message) CloneVT() *Uint32Message {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -193,6 +213,10 @@ func (m *Uint64Message) CloneVT() *Uint64Message {
 		tmpContainer := make([]uint64, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -224,6 +248,10 @@ func (m *Sint32Message) CloneVT() *Sint32Message {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -253,6 +281,10 @@ func (m *Sint64Message) CloneVT() *Sint64Message {
 		tmpContainer := make([]int64, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -284,6 +316,10 @@ func (m *Fixed32Message) CloneVT() *Fixed32Message {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -313,6 +349,10 @@ func (m *Fixed64Message) CloneVT() *Fixed64Message {
 		tmpContainer := make([]uint64, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -344,6 +384,10 @@ func (m *Sfixed32Message) CloneVT() *Sfixed32Message {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -373,6 +417,10 @@ func (m *Sfixed64Message) CloneVT() *Sfixed64Message {
 		tmpContainer := make([]int64, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -404,6 +452,10 @@ func (m *BoolMessage) CloneVT() *BoolMessage {
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -428,6 +480,10 @@ func (m *StringMessage) CloneVT() *StringMessage {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
 		r.RepeatedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }
@@ -460,6 +516,10 @@ func (m *BytesMessage) CloneVT() *BytesMessage {
 		}
 		r.RepeatedField = tmpContainer
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 
@@ -489,6 +549,10 @@ func (m *EnumMessage) CloneVT() *EnumMessage {
 		tmpContainer := make([]EnumMessage_Num, len(rhs))
 		copy(tmpContainer, rhs)
 		r.PackedField = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
 	}
 	return r
 }

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -91,6 +91,10 @@ func (m *OptionalFieldInProto3) CloneVT() *OptionalFieldInProto3 {
 		tmpVal := *rhs
 		r.OptionalEnum = &tmpVal
 	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
 	return r
 }
 


### PR DESCRIPTION
The existing implementation of `CloneVT` was silently discarding unknown fields, breaking some basic assumptions (such that a clone should always be equal to the original). Thus, extend the test generation to also copy unknown fields.

Unit tests are included.