### PR TITLE
equal: Fix handling of nil values

### DIFF
--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -217,9 +217,9 @@ func (m *JspbEncodingConfig) CloneGenericVT() proto.Message {
 
 func (this *FailureSet) EqualVT(that *FailureSet) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if len(this.Failure) != len(that.Failure) {
 		return false
@@ -235,9 +235,9 @@ func (this *FailureSet) EqualVT(that *FailureSet) bool {
 
 func (this *ConformanceRequest) EqualVT(that *ConformanceRequest) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.Payload == nil && that.Payload != nil {
 		return false
@@ -339,9 +339,9 @@ func (this *ConformanceRequest_TextPayload) EqualVT(thatIface isConformanceReque
 
 func (this *ConformanceResponse) EqualVT(that *ConformanceResponse) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.Result == nil && that.Result != nil {
 		return false
@@ -496,9 +496,9 @@ func (this *ConformanceResponse_TextPayload) EqualVT(thatIface isConformanceResp
 
 func (this *JspbEncodingConfig) EqualVT(that *JspbEncodingConfig) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.UseJspbArrayAnyFormat != that.UseJspbArrayAnyFormat {
 		return false

--- a/conformance/internal/conformance/equalvt_test.go
+++ b/conformance/internal/conformance/equalvt_test.go
@@ -307,3 +307,63 @@ func TestEqualVT_Proto3_BytesNoPresence(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestEqualVT_NilVsEmpty(t *testing.T) {
+	cases := map[string][2]*TestAllTypesProto3{
+		"nil and empty should not be equal": {
+			&TestAllTypesProto3{},
+			(*TestAllTypesProto3)(nil),
+		},
+		"nil and empty message field should not be equal": {
+			&TestAllTypesProto3{
+				OptionalNestedMessage: &TestAllTypesProto3_NestedMessage{},
+			},
+			&TestAllTypesProto3{
+				OptionalNestedMessage: nil,
+			},
+		},
+		"nil and empty message should be equal in slice": {
+			&TestAllTypesProto3{
+				RepeatedNestedMessage: []*TestAllTypesProto3_NestedMessage{{}},
+			},
+			&TestAllTypesProto3{
+				RepeatedNestedMessage: []*TestAllTypesProto3_NestedMessage{nil},
+			},
+		},
+		"nil and empty message should be equal in map value": {
+			&TestAllTypesProto3{
+				MapStringNestedMessage: map[string]*TestAllTypesProto3_NestedMessage{
+					"": {},
+				},
+			},
+			&TestAllTypesProto3{
+				MapStringNestedMessage: map[string]*TestAllTypesProto3_NestedMessage{
+					"": nil,
+				},
+			},
+		},
+		"nil and empty message should be equal in oneof": {
+			&TestAllTypesProto3{
+				OneofField: &TestAllTypesProto3_OneofNestedMessage{
+					OneofNestedMessage: &TestAllTypesProto3_NestedMessage{},
+				},
+			},
+			&TestAllTypesProto3{
+				OneofField: &TestAllTypesProto3_OneofNestedMessage{
+					OneofNestedMessage: nil,
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		cc := c // avoid loop closure bug
+		t.Run(name, func(t *testing.T) {
+			if proto.Equal(cc[0], cc[1]) {
+				assert.Truef(t, cc[0].EqualVT(cc[1]), "these %T should be equal:\nfirst = %+v\nsecond = %+v\n", cc[0], cc[0], cc[1])
+			} else {
+				assert.Falsef(t, cc[0].EqualVT(cc[1]), "these %T should not be equal:\nfirst = %+v\nsecond = %+v\n", cc[0], cc[0], cc[1])
+			}
+		})
+	}
+}

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -922,9 +922,9 @@ func (m *OneStringProto2) CloneGenericVT() proto.Message {
 
 func (this *TestAllTypesProto2_NestedMessage) EqualVT(that *TestAllTypesProto2_NestedMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.A, that.A; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -937,9 +937,9 @@ func (this *TestAllTypesProto2_NestedMessage) EqualVT(that *TestAllTypesProto2_N
 
 func (this *TestAllTypesProto2_Data) EqualVT(that *TestAllTypesProto2_Data) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.GroupInt32, that.GroupInt32; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -952,18 +952,18 @@ func (this *TestAllTypesProto2_Data) EqualVT(that *TestAllTypesProto2_Data) bool
 
 func (this *TestAllTypesProto2_MessageSetCorrect) EqualVT(that *TestAllTypesProto2_MessageSetCorrect) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *TestAllTypesProto2_MessageSetCorrectExtension1) EqualVT(that *TestAllTypesProto2_MessageSetCorrectExtension1) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.Str, that.Str; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -973,9 +973,9 @@ func (this *TestAllTypesProto2_MessageSetCorrectExtension1) EqualVT(that *TestAl
 
 func (this *TestAllTypesProto2_MessageSetCorrectExtension2) EqualVT(that *TestAllTypesProto2_MessageSetCorrectExtension2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.I, that.I; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -985,9 +985,9 @@ func (this *TestAllTypesProto2_MessageSetCorrectExtension2) EqualVT(that *TestAl
 
 func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.OneofField == nil && that.OneofField != nil {
 		return false
@@ -1207,8 +1207,16 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	}
 	for i, vx := range this.RepeatedNestedMessage {
 		vy := that.RepeatedNestedMessage[i]
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &TestAllTypesProto2_NestedMessage{}
+			}
+			if q == nil {
+				q = &TestAllTypesProto2_NestedMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.RepeatedForeignMessage) != len(that.RepeatedForeignMessage) {
@@ -1216,8 +1224,16 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	}
 	for i, vx := range this.RepeatedForeignMessage {
 		vy := that.RepeatedForeignMessage[i]
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ForeignMessageProto2{}
+			}
+			if q == nil {
+				q = &ForeignMessageProto2{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.RepeatedNestedEnum) != len(that.RepeatedNestedEnum) {
@@ -1444,8 +1460,16 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 		if !ok {
 			return false
 		}
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &TestAllTypesProto2_NestedMessage{}
+			}
+			if q == nil {
+				q = &TestAllTypesProto2_NestedMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.MapStringForeignMessage) != len(that.MapStringForeignMessage) {
@@ -1456,8 +1480,16 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 		if !ok {
 			return false
 		}
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ForeignMessageProto2{}
+			}
+			if q == nil {
+				q = &ForeignMessageProto2{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.MapStringNestedEnum) != len(that.MapStringNestedEnum) {
@@ -1869,8 +1901,16 @@ func (this *TestAllTypesProto2_OneofNestedMessage) EqualVT(thatIface isTestAllTy
 	if this == nil && that != nil || this != nil && that == nil {
 		return false
 	}
-	if !this.OneofNestedMessage.EqualVT(that.OneofNestedMessage) {
-		return false
+	if p, q := this.OneofNestedMessage, that.OneofNestedMessage; p != q {
+		if p == nil {
+			p = &TestAllTypesProto2_NestedMessage{}
+		}
+		if q == nil {
+			q = &TestAllTypesProto2_NestedMessage{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
 	}
 	return true
 }
@@ -1996,9 +2036,9 @@ func (this *TestAllTypesProto2_OneofEnum) EqualVT(thatIface isTestAllTypesProto2
 
 func (this *ForeignMessageProto2) EqualVT(that *ForeignMessageProto2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.C, that.C; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -2008,9 +2048,9 @@ func (this *ForeignMessageProto2) EqualVT(that *ForeignMessageProto2) bool {
 
 func (this *UnknownToTestAllTypes_OptionalGroup) EqualVT(that *UnknownToTestAllTypes_OptionalGroup) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.A, that.A; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -2020,9 +2060,9 @@ func (this *UnknownToTestAllTypes_OptionalGroup) EqualVT(that *UnknownToTestAllT
 
 func (this *UnknownToTestAllTypes) EqualVT(that *UnknownToTestAllTypes) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.OptionalInt32, that.OptionalInt32; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -2053,27 +2093,27 @@ func (this *UnknownToTestAllTypes) EqualVT(that *UnknownToTestAllTypes) bool {
 
 func (this *NullHypothesisProto2) EqualVT(that *NullHypothesisProto2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *EnumOnlyProto2) EqualVT(that *EnumOnlyProto2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *OneStringProto2) EqualVT(that *OneStringProto2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.Data, that.Data; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -933,9 +933,9 @@ func (m *EnumOnlyProto3) CloneGenericVT() proto.Message {
 
 func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_NestedMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.A != that.A {
 		return false
@@ -948,9 +948,9 @@ func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_N
 
 func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.OneofField == nil && that.OneofField != nil {
 		return false
@@ -1173,8 +1173,16 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedNestedMessage {
 		vy := that.RepeatedNestedMessage[i]
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &TestAllTypesProto3_NestedMessage{}
+			}
+			if q == nil {
+				q = &TestAllTypesProto3_NestedMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.RepeatedForeignMessage) != len(that.RepeatedForeignMessage) {
@@ -1182,8 +1190,16 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedForeignMessage {
 		vy := that.RepeatedForeignMessage[i]
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ForeignMessage{}
+			}
+			if q == nil {
+				q = &ForeignMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.RepeatedNestedEnum) != len(that.RepeatedNestedEnum) {
@@ -1410,8 +1426,16 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 		if !ok {
 			return false
 		}
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &TestAllTypesProto3_NestedMessage{}
+			}
+			if q == nil {
+				q = &TestAllTypesProto3_NestedMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.MapStringForeignMessage) != len(that.MapStringForeignMessage) {
@@ -1422,8 +1446,16 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 		if !ok {
 			return false
 		}
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ForeignMessage{}
+			}
+			if q == nil {
+				q = &ForeignMessage{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	if len(this.MapStringNestedEnum) != len(that.MapStringNestedEnum) {
@@ -1788,14 +1820,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedBoolWrapper {
 		vy := that.RepeatedBoolWrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.BoolValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.BoolValue{}
+			}
+			if q == nil {
+				q = &wrapperspb.BoolValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.BoolValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedInt32Wrapper) != len(that.RepeatedInt32Wrapper) {
@@ -1803,14 +1843,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedInt32Wrapper {
 		vy := that.RepeatedInt32Wrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.Int32Value) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.Int32Value{}
+			}
+			if q == nil {
+				q = &wrapperspb.Int32Value{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.Int32Value) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedInt64Wrapper) != len(that.RepeatedInt64Wrapper) {
@@ -1818,14 +1866,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedInt64Wrapper {
 		vy := that.RepeatedInt64Wrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.Int64Value) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.Int64Value{}
+			}
+			if q == nil {
+				q = &wrapperspb.Int64Value{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.Int64Value) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedUint32Wrapper) != len(that.RepeatedUint32Wrapper) {
@@ -1833,14 +1889,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedUint32Wrapper {
 		vy := that.RepeatedUint32Wrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.UInt32Value) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.UInt32Value{}
+			}
+			if q == nil {
+				q = &wrapperspb.UInt32Value{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.UInt32Value) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedUint64Wrapper) != len(that.RepeatedUint64Wrapper) {
@@ -1848,14 +1912,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedUint64Wrapper {
 		vy := that.RepeatedUint64Wrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.UInt64Value) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.UInt64Value{}
+			}
+			if q == nil {
+				q = &wrapperspb.UInt64Value{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.UInt64Value) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedFloatWrapper) != len(that.RepeatedFloatWrapper) {
@@ -1863,14 +1935,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedFloatWrapper {
 		vy := that.RepeatedFloatWrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.FloatValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.FloatValue{}
+			}
+			if q == nil {
+				q = &wrapperspb.FloatValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.FloatValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedDoubleWrapper) != len(that.RepeatedDoubleWrapper) {
@@ -1878,14 +1958,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedDoubleWrapper {
 		vy := that.RepeatedDoubleWrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.DoubleValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.DoubleValue{}
+			}
+			if q == nil {
+				q = &wrapperspb.DoubleValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.DoubleValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedStringWrapper) != len(that.RepeatedStringWrapper) {
@@ -1893,14 +1981,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedStringWrapper {
 		vy := that.RepeatedStringWrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.StringValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.StringValue{}
+			}
+			if q == nil {
+				q = &wrapperspb.StringValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.StringValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedBytesWrapper) != len(that.RepeatedBytesWrapper) {
@@ -1908,14 +2004,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedBytesWrapper {
 		vy := that.RepeatedBytesWrapper[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*wrapperspb.BytesValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &wrapperspb.BytesValue{}
+			}
+			if q == nil {
+				q = &wrapperspb.BytesValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*wrapperspb.BytesValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if equal, ok := interface{}(this.OptionalDuration).(interface {
@@ -1974,14 +2078,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedDuration {
 		vy := that.RepeatedDuration[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*durationpb.Duration) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &durationpb.Duration{}
+			}
+			if q == nil {
+				q = &durationpb.Duration{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*durationpb.Duration) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedTimestamp) != len(that.RepeatedTimestamp) {
@@ -1989,14 +2101,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedTimestamp {
 		vy := that.RepeatedTimestamp[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*timestamppb.Timestamp) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &timestamppb.Timestamp{}
+			}
+			if q == nil {
+				q = &timestamppb.Timestamp{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*timestamppb.Timestamp) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedFieldmask) != len(that.RepeatedFieldmask) {
@@ -2004,14 +2124,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedFieldmask {
 		vy := that.RepeatedFieldmask[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*fieldmaskpb.FieldMask) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &fieldmaskpb.FieldMask{}
+			}
+			if q == nil {
+				q = &fieldmaskpb.FieldMask{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*fieldmaskpb.FieldMask) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedAny) != len(that.RepeatedAny) {
@@ -2019,12 +2147,20 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedAny {
 		vy := that.RepeatedAny[i]
-		if equal, ok := interface{}(vx).(interface{ EqualVT(*anypb.Any) bool }); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &anypb.Any{}
+			}
+			if q == nil {
+				q = &anypb.Any{}
+			}
+			if equal, ok := interface{}(p).(interface{ EqualVT(*anypb.Any) bool }); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedValue) != len(that.RepeatedValue) {
@@ -2032,12 +2168,20 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedValue {
 		vy := that.RepeatedValue[i]
-		if equal, ok := interface{}(vx).(interface{ EqualVT(*structpb.Value) bool }); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &structpb.Value{}
+			}
+			if q == nil {
+				q = &structpb.Value{}
+			}
+			if equal, ok := interface{}(p).(interface{ EqualVT(*structpb.Value) bool }); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedListValue) != len(that.RepeatedListValue) {
@@ -2045,14 +2189,22 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedListValue {
 		vy := that.RepeatedListValue[i]
-		if equal, ok := interface{}(vx).(interface {
-			EqualVT(*structpb.ListValue) bool
-		}); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &structpb.ListValue{}
+			}
+			if q == nil {
+				q = &structpb.ListValue{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*structpb.ListValue) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if len(this.RepeatedStruct) != len(that.RepeatedStruct) {
@@ -2060,12 +2212,20 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	}
 	for i, vx := range this.RepeatedStruct {
 		vy := that.RepeatedStruct[i]
-		if equal, ok := interface{}(vx).(interface{ EqualVT(*structpb.Struct) bool }); ok {
-			if !equal.EqualVT(vy) {
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &structpb.Struct{}
+			}
+			if q == nil {
+				q = &structpb.Struct{}
+			}
+			if equal, ok := interface{}(p).(interface{ EqualVT(*structpb.Struct) bool }); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
 				return false
 			}
-		} else if !proto.Equal(vx, vy) {
-			return false
 		}
 	}
 	if this.Fieldname1 != that.Fieldname1 {
@@ -2153,8 +2313,16 @@ func (this *TestAllTypesProto3_OneofNestedMessage) EqualVT(thatIface isTestAllTy
 	if this == nil && that != nil || this != nil && that == nil {
 		return false
 	}
-	if !this.OneofNestedMessage.EqualVT(that.OneofNestedMessage) {
-		return false
+	if p, q := this.OneofNestedMessage, that.OneofNestedMessage; p != q {
+		if p == nil {
+			p = &TestAllTypesProto3_NestedMessage{}
+		}
+		if q == nil {
+			q = &TestAllTypesProto3_NestedMessage{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
 	}
 	return true
 }
@@ -2297,9 +2465,9 @@ func (this *TestAllTypesProto3_OneofNullValue) EqualVT(thatIface isTestAllTypesP
 
 func (this *ForeignMessage) EqualVT(that *ForeignMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.C != that.C {
 		return false
@@ -2309,18 +2477,18 @@ func (this *ForeignMessage) EqualVT(that *ForeignMessage) bool {
 
 func (this *NullHypothesisProto3) EqualVT(that *NullHypothesisProto3) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *EnumOnlyProto3) EqualVT(that *EnumOnlyProto3) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }

--- a/features/equal/equal.go
+++ b/features/equal/equal.go
@@ -215,6 +215,9 @@ func (p *equal) compareBytes(lhs, rhs string, nullable bool) {
 
 func (p *equal) compareCall(lhs, rhs string, msg *protogen.Message, nullable bool) {
 	if !nullable {
+		// The p != q check is mostly intended to catch the lhs = nil, rhs = nil case in which we would pointlessly
+		// allocate not just one but two empty values. However, it also provides us with an extra scope to establish
+		// our p and q variables.
 		p.P(`if p, q := `, lhs, `, `, rhs, `; p != q {`)
 		defer p.P(`}`)
 

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -37,9 +37,9 @@ func (m *MemoryPoolExtension) CloneGenericVT() proto.Message {
 
 func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.Foo1 != that.Foo1 {
 		return false

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -103,9 +103,9 @@ func (m *Element2) CloneGenericVT() proto.Message {
 
 func (this *Test1) EqualVT(that *Test1) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if len(this.Sl) != len(that.Sl) {
 		return false
@@ -121,17 +121,25 @@ func (this *Test1) EqualVT(that *Test1) bool {
 
 func (this *Test2) EqualVT(that *Test2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if len(this.Sl) != len(that.Sl) {
 		return false
 	}
 	for i, vx := range this.Sl {
 		vy := that.Sl[i]
-		if !vx.EqualVT(vy) {
-			return false
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Slice2{}
+			}
+			if q == nil {
+				q = &Slice2{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -139,9 +147,9 @@ func (this *Test2) EqualVT(that *Test2) bool {
 
 func (this *Slice2) EqualVT(that *Slice2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if len(this.A) != len(that.A) {
 		return false
@@ -181,9 +189,9 @@ func (this *Slice2) EqualVT(that *Slice2) bool {
 
 func (this *Element2) EqualVT(that *Element2) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if this.A != that.A {
 		return false

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -499,9 +499,9 @@ func (m *EnumMessage) CloneGenericVT() proto.Message {
 
 func (this *DoubleMessage) EqualVT(that *DoubleMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -532,9 +532,9 @@ func (this *DoubleMessage) EqualVT(that *DoubleMessage) bool {
 
 func (this *FloatMessage) EqualVT(that *FloatMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -565,9 +565,9 @@ func (this *FloatMessage) EqualVT(that *FloatMessage) bool {
 
 func (this *Int32Message) EqualVT(that *Int32Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -598,9 +598,9 @@ func (this *Int32Message) EqualVT(that *Int32Message) bool {
 
 func (this *Int64Message) EqualVT(that *Int64Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -631,9 +631,9 @@ func (this *Int64Message) EqualVT(that *Int64Message) bool {
 
 func (this *Uint32Message) EqualVT(that *Uint32Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -664,9 +664,9 @@ func (this *Uint32Message) EqualVT(that *Uint32Message) bool {
 
 func (this *Uint64Message) EqualVT(that *Uint64Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -697,9 +697,9 @@ func (this *Uint64Message) EqualVT(that *Uint64Message) bool {
 
 func (this *Sint32Message) EqualVT(that *Sint32Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -730,9 +730,9 @@ func (this *Sint32Message) EqualVT(that *Sint32Message) bool {
 
 func (this *Sint64Message) EqualVT(that *Sint64Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -763,9 +763,9 @@ func (this *Sint64Message) EqualVT(that *Sint64Message) bool {
 
 func (this *Fixed32Message) EqualVT(that *Fixed32Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -796,9 +796,9 @@ func (this *Fixed32Message) EqualVT(that *Fixed32Message) bool {
 
 func (this *Fixed64Message) EqualVT(that *Fixed64Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -829,9 +829,9 @@ func (this *Fixed64Message) EqualVT(that *Fixed64Message) bool {
 
 func (this *Sfixed32Message) EqualVT(that *Sfixed32Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -862,9 +862,9 @@ func (this *Sfixed32Message) EqualVT(that *Sfixed32Message) bool {
 
 func (this *Sfixed64Message) EqualVT(that *Sfixed64Message) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -895,9 +895,9 @@ func (this *Sfixed64Message) EqualVT(that *Sfixed64Message) bool {
 
 func (this *BoolMessage) EqualVT(that *BoolMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -928,9 +928,9 @@ func (this *BoolMessage) EqualVT(that *BoolMessage) bool {
 
 func (this *StringMessage) EqualVT(that *StringMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
@@ -952,9 +952,9 @@ func (this *StringMessage) EqualVT(that *StringMessage) bool {
 
 func (this *BytesMessage) EqualVT(that *BytesMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && q == nil) || string(p) != string(q) {
 		return false
@@ -976,9 +976,9 @@ func (this *BytesMessage) EqualVT(that *BytesMessage) bool {
 
 func (this *EnumMessage) EqualVT(that *EnumMessage) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.RequiredField, that.RequiredField; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -100,9 +100,9 @@ func (m *OptionalFieldInProto3) CloneGenericVT() proto.Message {
 
 func (this *OptionalFieldInProto3) EqualVT(that *OptionalFieldInProto3) bool {
 	if this == nil {
-		return that == nil || that.String() == ""
+		return that == nil
 	} else if that == nil {
-		return this.String() == ""
+		return false
 	}
 	if p, q := this.OptionalInt32, that.OptionalInt32; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false


### PR DESCRIPTION
The current `equal` implementation generates code that recognizes a `nil` message as being equal to an empty message of the same type. However, [this is not how `proto.Equal` works](https://github.com/protocolbuffers/protobuf-go/blob/v1.28.1/proto/equal.go#L42), where a `nil` message is only equal to another `nil` message of the same type.

A complication arises from the fact that `nil` and empty message _values_ need to be treated as equal in certain contexts - slice elements, map values, oneofs. This is the same principle as the one described in https://github.com/planetscale/vtprotobuf/issues/52, only applied to messages instead of byte slices.

This PR solves this by propagating the `nullable` (i.e., presence) information to the code generator for comparing message values, and substituting `nil` values for empty ones for non-nullable values.