### PR TITLE
Add an EqualMessageVT generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ The following features can be generated:
 
 - `size`: generates a `func (p *YourProto) SizeVT() int` helper that behaves identically to calling `proto.Size(p)` on the message, except the size calculation is fully unrolled and does not use reflection. This helper function can be used directly, and it'll also be used by the `marshal` codegen to ensure the destination buffer is properly sized before ProtoBuf objects are marshalled to it.
 
-- `equal`: generates a `func (this *YourProto) EqualVT(that *YourProto) bool` helper that behaves almost identically to calling `proto.Equal(this, that)` on messages, except the equality calculation is fully unrolled and does not use reflection. This helper function can be used directly.
+- `equal`: generates the following helper methods
+
+    - `func (this *YourProto) EqualVT(that *YourProto) bool`: this function behaves almost identically to calling `proto.Equal(this, that)` on messages, except the equality calculation is fully unrolled and does not use reflection. This helper function can be used directly.
+
+    - `func (this *YourProto) EqualMessageVT(thatMsg proto.Message) bool`: this function behaves like the above `this.EqualVT(that)`, but allows comparing against arbitrary proto messages. If `thatMsg` is not of type `*YourProto`, false is returned. The uniform signature provided by this method allows accessing this method via type assertions even if the message type is not known at compile time. This allows implementing a generic `func EqualVT(proto.Message, proto.Message) bool` without reflection.
 
 - `marshal`: generates the following helper methods
 
@@ -36,7 +40,7 @@ The following features can be generated:
 
     - `func (p *YourProto) CloneVT() *YourProto`: this function behaves similarly to calling `proto.Clone(p)` on the message, except the cloning is performed by unrolled codegen without using reflection. If the receiver `p` is `nil` a typed `nil` is returned.
 
-    - `func (p *YourProto) CloneGenericVT() proto.Message`: this function behaves like the above `p.CloneVT()`, but provides a uniform signature in order to be accessible via type assertions even if the type is not known at compile time. This allows implementing a generic `func CloneVT(proto.Message)` without reflection. If the receiver `p` is `nil`, a typed `nil` pointer of the message type will be returned inside a `proto.Message` interface.
+    - `func (p *YourProto) CloneMessageVT() proto.Message`: this function behaves like the above `p.CloneVT()`, but provides a uniform signature in order to be accessible via type assertions even if the type is not known at compile time. This allows implementing a generic `func CloneVT(proto.Message)` without reflection. If the receiver `p` is `nil`, a typed `nil` pointer of the message type will be returned inside a `proto.Message` interface.
 
 ## Usage
 

--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -35,8 +35,13 @@ func (m *FailureSet) CloneVT() *FailureSet {
 	return r
 }
 
-func (m *FailureSet) CloneGenericVT() proto.Message {
+func (m *FailureSet) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *FailureSet) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *ConformanceRequest) CloneVT() *ConformanceRequest {
@@ -62,8 +67,13 @@ func (m *ConformanceRequest) CloneVT() *ConformanceRequest {
 	return r
 }
 
-func (m *ConformanceRequest) CloneGenericVT() proto.Message {
+func (m *ConformanceRequest) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *ConformanceRequest) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *ConformanceRequest_ProtobufPayload) CloneVT() isConformanceRequest_Payload {
@@ -126,8 +136,13 @@ func (m *ConformanceResponse) CloneVT() *ConformanceResponse {
 	return r
 }
 
-func (m *ConformanceResponse) CloneGenericVT() proto.Message {
+func (m *ConformanceResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *ConformanceResponse) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *ConformanceResponse_ParseError) CloneVT() isConformanceResponse_Result {
@@ -227,8 +242,13 @@ func (m *JspbEncodingConfig) CloneVT() *JspbEncodingConfig {
 	return r
 }
 
-func (m *JspbEncodingConfig) CloneGenericVT() proto.Message {
+func (m *JspbEncodingConfig) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *JspbEncodingConfig) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *FailureSet) EqualVT(that *FailureSet) bool {
@@ -249,6 +269,13 @@ func (this *FailureSet) EqualVT(that *FailureSet) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *FailureSet) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*FailureSet)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *ConformanceRequest) EqualVT(that *ConformanceRequest) bool {
 	if this == nil {
 		return that == nil
@@ -285,6 +312,13 @@ func (this *ConformanceRequest) EqualVT(that *ConformanceRequest) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *ConformanceRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ConformanceRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *ConformanceRequest_ProtobufPayload) EqualVT(thatIface isConformanceRequest_Payload) bool {
 	that, ok := thatIface.(*ConformanceRequest_ProtobufPayload)
 	if !ok {
@@ -374,6 +408,13 @@ func (this *ConformanceResponse) EqualVT(that *ConformanceResponse) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *ConformanceResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ConformanceResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *ConformanceResponse_ParseError) EqualVT(thatIface isConformanceResponse_Result) bool {
 	that, ok := thatIface.(*ConformanceResponse_ParseError)
 	if !ok {
@@ -522,6 +563,13 @@ func (this *JspbEncodingConfig) EqualVT(that *JspbEncodingConfig) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *JspbEncodingConfig) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*JspbEncodingConfig)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *FailureSet) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -39,8 +39,13 @@ func (m *TestAllTypesProto2_NestedMessage) CloneVT() *TestAllTypesProto2_NestedM
 	return r
 }
 
-func (m *TestAllTypesProto2_NestedMessage) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2_NestedMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2_NestedMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2_Data) CloneVT() *TestAllTypesProto2_Data {
@@ -63,8 +68,13 @@ func (m *TestAllTypesProto2_Data) CloneVT() *TestAllTypesProto2_Data {
 	return r
 }
 
-func (m *TestAllTypesProto2_Data) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2_Data) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2_Data) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2_MessageSetCorrect) CloneVT() *TestAllTypesProto2_MessageSetCorrect {
@@ -79,8 +89,13 @@ func (m *TestAllTypesProto2_MessageSetCorrect) CloneVT() *TestAllTypesProto2_Mes
 	return r
 }
 
-func (m *TestAllTypesProto2_MessageSetCorrect) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2_MessageSetCorrect) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2_MessageSetCorrect) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneVT() *TestAllTypesProto2_MessageSetCorrectExtension1 {
@@ -99,8 +114,13 @@ func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneVT() *TestAllTypes
 	return r
 }
 
-func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneVT() *TestAllTypesProto2_MessageSetCorrectExtension2 {
@@ -119,8 +139,13 @@ func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneVT() *TestAllTypes
 	return r
 }
 
-func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2) CloneVT() *TestAllTypesProto2 {
@@ -743,8 +768,13 @@ func (m *TestAllTypesProto2) CloneVT() *TestAllTypesProto2 {
 	return r
 }
 
-func (m *TestAllTypesProto2) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto2_OneofUint32) CloneVT() isTestAllTypesProto2_OneofField {
@@ -856,8 +886,13 @@ func (m *ForeignMessageProto2) CloneVT() *ForeignMessageProto2 {
 	return r
 }
 
-func (m *ForeignMessageProto2) CloneGenericVT() proto.Message {
+func (m *ForeignMessageProto2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *ForeignMessageProto2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *UnknownToTestAllTypes_OptionalGroup) CloneVT() *UnknownToTestAllTypes_OptionalGroup {
@@ -876,8 +911,13 @@ func (m *UnknownToTestAllTypes_OptionalGroup) CloneVT() *UnknownToTestAllTypes_O
 	return r
 }
 
-func (m *UnknownToTestAllTypes_OptionalGroup) CloneGenericVT() proto.Message {
+func (m *UnknownToTestAllTypes_OptionalGroup) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *UnknownToTestAllTypes_OptionalGroup) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *UnknownToTestAllTypes) CloneVT() *UnknownToTestAllTypes {
@@ -912,8 +952,13 @@ func (m *UnknownToTestAllTypes) CloneVT() *UnknownToTestAllTypes {
 	return r
 }
 
-func (m *UnknownToTestAllTypes) CloneGenericVT() proto.Message {
+func (m *UnknownToTestAllTypes) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *UnknownToTestAllTypes) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *NullHypothesisProto2) CloneVT() *NullHypothesisProto2 {
@@ -928,8 +973,13 @@ func (m *NullHypothesisProto2) CloneVT() *NullHypothesisProto2 {
 	return r
 }
 
-func (m *NullHypothesisProto2) CloneGenericVT() proto.Message {
+func (m *NullHypothesisProto2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *NullHypothesisProto2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *EnumOnlyProto2) CloneVT() *EnumOnlyProto2 {
@@ -944,8 +994,13 @@ func (m *EnumOnlyProto2) CloneVT() *EnumOnlyProto2 {
 	return r
 }
 
-func (m *EnumOnlyProto2) CloneGenericVT() proto.Message {
+func (m *EnumOnlyProto2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *EnumOnlyProto2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *OneStringProto2) CloneVT() *OneStringProto2 {
@@ -964,8 +1019,13 @@ func (m *OneStringProto2) CloneVT() *OneStringProto2 {
 	return r
 }
 
-func (m *OneStringProto2) CloneGenericVT() proto.Message {
+func (m *OneStringProto2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *OneStringProto2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *TestAllTypesProto2_NestedMessage) EqualVT(that *TestAllTypesProto2_NestedMessage) bool {
@@ -983,6 +1043,13 @@ func (this *TestAllTypesProto2_NestedMessage) EqualVT(that *TestAllTypesProto2_N
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2_NestedMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2_NestedMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2_Data) EqualVT(that *TestAllTypesProto2_Data) bool {
 	if this == nil {
 		return that == nil
@@ -998,6 +1065,13 @@ func (this *TestAllTypesProto2_Data) EqualVT(that *TestAllTypesProto2_Data) bool
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2_Data) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2_Data)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2_MessageSetCorrect) EqualVT(that *TestAllTypesProto2_MessageSetCorrect) bool {
 	if this == nil {
 		return that == nil
@@ -1007,6 +1081,13 @@ func (this *TestAllTypesProto2_MessageSetCorrect) EqualVT(that *TestAllTypesProt
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2_MessageSetCorrect) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2_MessageSetCorrect)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2_MessageSetCorrectExtension1) EqualVT(that *TestAllTypesProto2_MessageSetCorrectExtension1) bool {
 	if this == nil {
 		return that == nil
@@ -1019,6 +1100,13 @@ func (this *TestAllTypesProto2_MessageSetCorrectExtension1) EqualVT(that *TestAl
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2_MessageSetCorrectExtension1) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2_MessageSetCorrectExtension1)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2_MessageSetCorrectExtension2) EqualVT(that *TestAllTypesProto2_MessageSetCorrectExtension2) bool {
 	if this == nil {
 		return that == nil
@@ -1031,6 +1119,13 @@ func (this *TestAllTypesProto2_MessageSetCorrectExtension2) EqualVT(that *TestAl
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2_MessageSetCorrectExtension2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2_MessageSetCorrectExtension2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	if this == nil {
 		return that == nil
@@ -1921,6 +2016,13 @@ func (this *TestAllTypesProto2) EqualVT(that *TestAllTypesProto2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto2_OneofUint32) EqualVT(thatIface isTestAllTypesProto2_OneofField) bool {
 	that, ok := thatIface.(*TestAllTypesProto2_OneofUint32)
 	if !ok {
@@ -2094,6 +2196,13 @@ func (this *ForeignMessageProto2) EqualVT(that *ForeignMessageProto2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *ForeignMessageProto2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ForeignMessageProto2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *UnknownToTestAllTypes_OptionalGroup) EqualVT(that *UnknownToTestAllTypes_OptionalGroup) bool {
 	if this == nil {
 		return that == nil
@@ -2106,6 +2215,13 @@ func (this *UnknownToTestAllTypes_OptionalGroup) EqualVT(that *UnknownToTestAllT
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *UnknownToTestAllTypes_OptionalGroup) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*UnknownToTestAllTypes_OptionalGroup)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *UnknownToTestAllTypes) EqualVT(that *UnknownToTestAllTypes) bool {
 	if this == nil {
 		return that == nil
@@ -2139,6 +2255,13 @@ func (this *UnknownToTestAllTypes) EqualVT(that *UnknownToTestAllTypes) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *UnknownToTestAllTypes) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*UnknownToTestAllTypes)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *NullHypothesisProto2) EqualVT(that *NullHypothesisProto2) bool {
 	if this == nil {
 		return that == nil
@@ -2148,6 +2271,13 @@ func (this *NullHypothesisProto2) EqualVT(that *NullHypothesisProto2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *NullHypothesisProto2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*NullHypothesisProto2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *EnumOnlyProto2) EqualVT(that *EnumOnlyProto2) bool {
 	if this == nil {
 		return that == nil
@@ -2157,6 +2287,13 @@ func (this *EnumOnlyProto2) EqualVT(that *EnumOnlyProto2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *EnumOnlyProto2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*EnumOnlyProto2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *OneStringProto2) EqualVT(that *OneStringProto2) bool {
 	if this == nil {
 		return that == nil
@@ -2169,6 +2306,13 @@ func (this *OneStringProto2) EqualVT(that *OneStringProto2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *OneStringProto2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*OneStringProto2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *TestAllTypesProto2_NestedMessage) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -41,8 +41,13 @@ func (m *TestAllTypesProto3_NestedMessage) CloneVT() *TestAllTypesProto3_NestedM
 	return r
 }
 
-func (m *TestAllTypesProto3_NestedMessage) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto3_NestedMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto3_NestedMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
@@ -794,8 +799,13 @@ func (m *TestAllTypesProto3) CloneVT() *TestAllTypesProto3 {
 	return r
 }
 
-func (m *TestAllTypesProto3) CloneGenericVT() proto.Message {
+func (m *TestAllTypesProto3) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *TestAllTypesProto3) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *TestAllTypesProto3_OneofUint32) CloneVT() isTestAllTypesProto3_OneofField {
@@ -915,8 +925,13 @@ func (m *ForeignMessage) CloneVT() *ForeignMessage {
 	return r
 }
 
-func (m *ForeignMessage) CloneGenericVT() proto.Message {
+func (m *ForeignMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *ForeignMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *NullHypothesisProto3) CloneVT() *NullHypothesisProto3 {
@@ -931,8 +946,13 @@ func (m *NullHypothesisProto3) CloneVT() *NullHypothesisProto3 {
 	return r
 }
 
-func (m *NullHypothesisProto3) CloneGenericVT() proto.Message {
+func (m *NullHypothesisProto3) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *NullHypothesisProto3) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *EnumOnlyProto3) CloneVT() *EnumOnlyProto3 {
@@ -947,8 +967,13 @@ func (m *EnumOnlyProto3) CloneVT() *EnumOnlyProto3 {
 	return r
 }
 
-func (m *EnumOnlyProto3) CloneGenericVT() proto.Message {
+func (m *EnumOnlyProto3) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *EnumOnlyProto3) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_NestedMessage) bool {
@@ -966,6 +991,13 @@ func (this *TestAllTypesProto3_NestedMessage) EqualVT(that *TestAllTypesProto3_N
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto3_NestedMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto3_NestedMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	if this == nil {
 		return that == nil
@@ -2305,6 +2337,13 @@ func (this *TestAllTypesProto3) EqualVT(that *TestAllTypesProto3) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *TestAllTypesProto3) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TestAllTypesProto3)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TestAllTypesProto3_OneofUint32) EqualVT(thatIface isTestAllTypesProto3_OneofField) bool {
 	that, ok := thatIface.(*TestAllTypesProto3_OneofUint32)
 	if !ok {
@@ -2495,6 +2534,13 @@ func (this *ForeignMessage) EqualVT(that *ForeignMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *ForeignMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ForeignMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *NullHypothesisProto3) EqualVT(that *NullHypothesisProto3) bool {
 	if this == nil {
 		return that == nil
@@ -2504,6 +2550,13 @@ func (this *NullHypothesisProto3) EqualVT(that *NullHypothesisProto3) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *NullHypothesisProto3) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*NullHypothesisProto3)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *EnumOnlyProto3) EqualVT(that *EnumOnlyProto3) bool {
 	if this == nil {
 		return that == nil
@@ -2513,6 +2566,13 @@ func (this *EnumOnlyProto3) EqualVT(that *EnumOnlyProto3) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *EnumOnlyProto3) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*EnumOnlyProto3)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *TestAllTypesProto3_NestedMessage) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/features/clone/clone.go
+++ b/features/clone/clone.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	cloneName        = "CloneVT"
+	cloneMessageName = "CloneMessageVT"
 	cloneGenericName = "CloneGenericVT"
 )
 
@@ -147,8 +148,13 @@ func (p *clone) generateCloneMethodsForMessage(proto3 bool, message *protogen.Me
 	p.body(!proto3, ccTypeName, message.Fields, true)
 	p.P(`}`)
 	p.P()
-	p.P(`func (m *`, ccTypeName, `) `, cloneGenericName, `() `, protoPkg.Ident("Message"), ` {`)
+	p.P(`func (m *`, ccTypeName, `) `, cloneMessageName, `() `, protoPkg.Ident("Message"), ` {`)
 	p.P(`return m.`, cloneName, `()`)
+	p.P(`}`)
+	p.P()
+	p.P(`// Deprecated: use `, cloneMessageName, ` instead`)
+	p.P(`func (m *`, ccTypeName, `) `, cloneGenericName, `() `, protoPkg.Ident("Message"), ` {`)
+	p.P(`return m.`, cloneMessageName, `()`)
 	p.P(`}`)
 	p.P()
 }

--- a/features/equal/equal.go
+++ b/features/equal/equal.go
@@ -18,6 +18,10 @@ func init() {
 	})
 }
 
+var (
+	protoPkg = protogen.GoImportPath("google.golang.org/protobuf/proto")
+)
+
 type equal struct {
 	*generator.GeneratedFile
 	once bool
@@ -36,6 +40,7 @@ func (p *equal) GenerateFile(file *protogen.File) bool {
 }
 
 const equalName = "EqualVT"
+const equalMessageName = "EqualMessageVT"
 
 func (p *equal) message(proto3 bool, message *protogen.Message) {
 	for _, nested := range message.Messages {
@@ -100,6 +105,14 @@ func (p *equal) message(proto3 bool, message *protogen.Message) {
 	p.P(`return string(this.unknownFields) == string(that.unknownFields)`)
 	p.P(`}`)
 	p.P()
+
+	p.P(`func (this *`, ccTypeName, `) `, equalMessageName, `(thatMsg `, protoPkg.Ident("Message"), `) bool {`)
+	p.P(`that, ok := thatMsg.(*`, ccTypeName, `)`)
+	p.P(`if !ok {`)
+	p.P(`return false`)
+	p.P(`}`)
+	p.P(`return this.`, equalName, `(that)`)
+	p.P(`}`)
 
 	for _, field := range message.Fields {
 		oneof := field.Oneof != nil && !field.Oneof.Desc.IsSynthetic()

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -35,8 +35,13 @@ func (m *MemoryPoolExtension) CloneVT() *MemoryPoolExtension {
 	return r
 }
 
-func (m *MemoryPoolExtension) CloneGenericVT() proto.Message {
+func (m *MemoryPoolExtension) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *MemoryPoolExtension) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
@@ -54,6 +59,13 @@ func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *MemoryPoolExtension) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MemoryPoolExtension)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *MemoryPoolExtension) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -36,8 +36,13 @@ func (m *Test1) CloneVT() *Test1 {
 	return r
 }
 
-func (m *Test1) CloneGenericVT() proto.Message {
+func (m *Test1) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Test1) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Test2) CloneVT() *Test2 {
@@ -59,8 +64,13 @@ func (m *Test2) CloneVT() *Test2 {
 	return r
 }
 
-func (m *Test2) CloneGenericVT() proto.Message {
+func (m *Test2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Test2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Slice2) CloneVT() *Slice2 {
@@ -95,8 +105,13 @@ func (m *Slice2) CloneVT() *Slice2 {
 	return r
 }
 
-func (m *Slice2) CloneGenericVT() proto.Message {
+func (m *Slice2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Slice2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Element2) CloneVT() *Element2 {
@@ -113,8 +128,13 @@ func (m *Element2) CloneVT() *Element2 {
 	return r
 }
 
-func (m *Element2) CloneGenericVT() proto.Message {
+func (m *Element2) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Element2) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *Test1) EqualVT(that *Test1) bool {
@@ -135,6 +155,13 @@ func (this *Test1) EqualVT(that *Test1) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Test1) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Test1)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Test2) EqualVT(that *Test2) bool {
 	if this == nil {
 		return that == nil
@@ -161,6 +188,13 @@ func (this *Test2) EqualVT(that *Test2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Test2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Test2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Slice2) EqualVT(that *Slice2) bool {
 	if this == nil {
 		return that == nil
@@ -203,6 +237,13 @@ func (this *Slice2) EqualVT(that *Slice2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Slice2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Slice2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Element2) EqualVT(that *Element2) bool {
 	if this == nil {
 		return that == nil
@@ -215,6 +256,13 @@ func (this *Element2) EqualVT(that *Element2) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Element2) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Element2)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *Test1) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -51,8 +51,13 @@ func (m *DoubleMessage) CloneVT() *DoubleMessage {
 	return r
 }
 
-func (m *DoubleMessage) CloneGenericVT() proto.Message {
+func (m *DoubleMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *DoubleMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *FloatMessage) CloneVT() *FloatMessage {
@@ -85,8 +90,13 @@ func (m *FloatMessage) CloneVT() *FloatMessage {
 	return r
 }
 
-func (m *FloatMessage) CloneGenericVT() proto.Message {
+func (m *FloatMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *FloatMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Int32Message) CloneVT() *Int32Message {
@@ -119,8 +129,13 @@ func (m *Int32Message) CloneVT() *Int32Message {
 	return r
 }
 
-func (m *Int32Message) CloneGenericVT() proto.Message {
+func (m *Int32Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Int32Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Int64Message) CloneVT() *Int64Message {
@@ -153,8 +168,13 @@ func (m *Int64Message) CloneVT() *Int64Message {
 	return r
 }
 
-func (m *Int64Message) CloneGenericVT() proto.Message {
+func (m *Int64Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Int64Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Uint32Message) CloneVT() *Uint32Message {
@@ -187,8 +207,13 @@ func (m *Uint32Message) CloneVT() *Uint32Message {
 	return r
 }
 
-func (m *Uint32Message) CloneGenericVT() proto.Message {
+func (m *Uint32Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Uint32Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Uint64Message) CloneVT() *Uint64Message {
@@ -221,8 +246,13 @@ func (m *Uint64Message) CloneVT() *Uint64Message {
 	return r
 }
 
-func (m *Uint64Message) CloneGenericVT() proto.Message {
+func (m *Uint64Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Uint64Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Sint32Message) CloneVT() *Sint32Message {
@@ -255,8 +285,13 @@ func (m *Sint32Message) CloneVT() *Sint32Message {
 	return r
 }
 
-func (m *Sint32Message) CloneGenericVT() proto.Message {
+func (m *Sint32Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Sint32Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Sint64Message) CloneVT() *Sint64Message {
@@ -289,8 +324,13 @@ func (m *Sint64Message) CloneVT() *Sint64Message {
 	return r
 }
 
-func (m *Sint64Message) CloneGenericVT() proto.Message {
+func (m *Sint64Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Sint64Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Fixed32Message) CloneVT() *Fixed32Message {
@@ -323,8 +363,13 @@ func (m *Fixed32Message) CloneVT() *Fixed32Message {
 	return r
 }
 
-func (m *Fixed32Message) CloneGenericVT() proto.Message {
+func (m *Fixed32Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Fixed32Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Fixed64Message) CloneVT() *Fixed64Message {
@@ -357,8 +402,13 @@ func (m *Fixed64Message) CloneVT() *Fixed64Message {
 	return r
 }
 
-func (m *Fixed64Message) CloneGenericVT() proto.Message {
+func (m *Fixed64Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Fixed64Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Sfixed32Message) CloneVT() *Sfixed32Message {
@@ -391,8 +441,13 @@ func (m *Sfixed32Message) CloneVT() *Sfixed32Message {
 	return r
 }
 
-func (m *Sfixed32Message) CloneGenericVT() proto.Message {
+func (m *Sfixed32Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Sfixed32Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *Sfixed64Message) CloneVT() *Sfixed64Message {
@@ -425,8 +480,13 @@ func (m *Sfixed64Message) CloneVT() *Sfixed64Message {
 	return r
 }
 
-func (m *Sfixed64Message) CloneGenericVT() proto.Message {
+func (m *Sfixed64Message) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *Sfixed64Message) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *BoolMessage) CloneVT() *BoolMessage {
@@ -459,8 +519,13 @@ func (m *BoolMessage) CloneVT() *BoolMessage {
 	return r
 }
 
-func (m *BoolMessage) CloneGenericVT() proto.Message {
+func (m *BoolMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *BoolMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *StringMessage) CloneVT() *StringMessage {
@@ -488,8 +553,13 @@ func (m *StringMessage) CloneVT() *StringMessage {
 	return r
 }
 
-func (m *StringMessage) CloneGenericVT() proto.Message {
+func (m *StringMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *StringMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *BytesMessage) CloneVT() *BytesMessage {
@@ -523,8 +593,13 @@ func (m *BytesMessage) CloneVT() *BytesMessage {
 	return r
 }
 
-func (m *BytesMessage) CloneGenericVT() proto.Message {
+func (m *BytesMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *BytesMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (m *EnumMessage) CloneVT() *EnumMessage {
@@ -557,8 +632,13 @@ func (m *EnumMessage) CloneVT() *EnumMessage {
 	return r
 }
 
-func (m *EnumMessage) CloneGenericVT() proto.Message {
+func (m *EnumMessage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *EnumMessage) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *DoubleMessage) EqualVT(that *DoubleMessage) bool {
@@ -594,6 +674,13 @@ func (this *DoubleMessage) EqualVT(that *DoubleMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *DoubleMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DoubleMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *FloatMessage) EqualVT(that *FloatMessage) bool {
 	if this == nil {
 		return that == nil
@@ -627,6 +714,13 @@ func (this *FloatMessage) EqualVT(that *FloatMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *FloatMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*FloatMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Int32Message) EqualVT(that *Int32Message) bool {
 	if this == nil {
 		return that == nil
@@ -660,6 +754,13 @@ func (this *Int32Message) EqualVT(that *Int32Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Int32Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Int32Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Int64Message) EqualVT(that *Int64Message) bool {
 	if this == nil {
 		return that == nil
@@ -693,6 +794,13 @@ func (this *Int64Message) EqualVT(that *Int64Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Int64Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Int64Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Uint32Message) EqualVT(that *Uint32Message) bool {
 	if this == nil {
 		return that == nil
@@ -726,6 +834,13 @@ func (this *Uint32Message) EqualVT(that *Uint32Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Uint32Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Uint32Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Uint64Message) EqualVT(that *Uint64Message) bool {
 	if this == nil {
 		return that == nil
@@ -759,6 +874,13 @@ func (this *Uint64Message) EqualVT(that *Uint64Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Uint64Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Uint64Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Sint32Message) EqualVT(that *Sint32Message) bool {
 	if this == nil {
 		return that == nil
@@ -792,6 +914,13 @@ func (this *Sint32Message) EqualVT(that *Sint32Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Sint32Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Sint32Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Sint64Message) EqualVT(that *Sint64Message) bool {
 	if this == nil {
 		return that == nil
@@ -825,6 +954,13 @@ func (this *Sint64Message) EqualVT(that *Sint64Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Sint64Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Sint64Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Fixed32Message) EqualVT(that *Fixed32Message) bool {
 	if this == nil {
 		return that == nil
@@ -858,6 +994,13 @@ func (this *Fixed32Message) EqualVT(that *Fixed32Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Fixed32Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Fixed32Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Fixed64Message) EqualVT(that *Fixed64Message) bool {
 	if this == nil {
 		return that == nil
@@ -891,6 +1034,13 @@ func (this *Fixed64Message) EqualVT(that *Fixed64Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Fixed64Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Fixed64Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Sfixed32Message) EqualVT(that *Sfixed32Message) bool {
 	if this == nil {
 		return that == nil
@@ -924,6 +1074,13 @@ func (this *Sfixed32Message) EqualVT(that *Sfixed32Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Sfixed32Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Sfixed32Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Sfixed64Message) EqualVT(that *Sfixed64Message) bool {
 	if this == nil {
 		return that == nil
@@ -957,6 +1114,13 @@ func (this *Sfixed64Message) EqualVT(that *Sfixed64Message) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *Sfixed64Message) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Sfixed64Message)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *BoolMessage) EqualVT(that *BoolMessage) bool {
 	if this == nil {
 		return that == nil
@@ -990,6 +1154,13 @@ func (this *BoolMessage) EqualVT(that *BoolMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *BoolMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*BoolMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *StringMessage) EqualVT(that *StringMessage) bool {
 	if this == nil {
 		return that == nil
@@ -1014,6 +1185,13 @@ func (this *StringMessage) EqualVT(that *StringMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *StringMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StringMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *BytesMessage) EqualVT(that *BytesMessage) bool {
 	if this == nil {
 		return that == nil
@@ -1038,6 +1216,13 @@ func (this *BytesMessage) EqualVT(that *BytesMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *BytesMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*BytesMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *EnumMessage) EqualVT(that *EnumMessage) bool {
 	if this == nil {
 		return that == nil
@@ -1071,6 +1256,13 @@ func (this *EnumMessage) EqualVT(that *EnumMessage) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *EnumMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*EnumMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *DoubleMessage) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -98,8 +98,13 @@ func (m *OptionalFieldInProto3) CloneVT() *OptionalFieldInProto3 {
 	return r
 }
 
-func (m *OptionalFieldInProto3) CloneGenericVT() proto.Message {
+func (m *OptionalFieldInProto3) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+// Deprecated: use CloneMessageVT instead
+func (m *OptionalFieldInProto3) CloneGenericVT() proto.Message {
+	return m.CloneMessageVT()
 }
 
 func (this *OptionalFieldInProto3) EqualVT(that *OptionalFieldInProto3) bool {
@@ -159,6 +164,13 @@ func (this *OptionalFieldInProto3) EqualVT(that *OptionalFieldInProto3) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
+func (this *OptionalFieldInProto3) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*OptionalFieldInProto3)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *OptionalFieldInProto3) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil


### PR DESCRIPTION
This PR adds a generator that makes `EqualVT` accessible with a uniform signature as `EqualMessageVT(proto.Message) bool`.

The main motivation is to ease migration from Gogo protobuf by offering a drop-in replacement for `"github.com/gogo/protobuf/proto".Equal`, which uses optimized code where available. With the change in this PR, this can simply be done via

```
func Equal(a, b proto.Message) bool {
  if aVT, ok := a.(interface{ EqualMessageVT(proto.Message) bool }); ok {
    return aVT.EqualMessageVT(b)
  }
  // we can disregard checking b because if a and b are not of the same type, Equal will be fast anyway
  return proto.Equal(a, b) // from google.golang.org/protobuf/proto
}
```

I had added a similar facility when adding `CloneVT` via `CloneGenericVT`. However, with the launch of generics in go1.18, this naming has not aged well. I therefore adopted `...Message...` for the variant accepting a `proto.Message`, and have also applied this by renaming `CloneGenericVT` to `CloneMessageVT` (the old variant is still generated for backwards-compatibility, but marked deprecated).