### PR TITLE
Fixes missing Reset in ResetVT

### DIFF
--- a/features/pool/pool.go
+++ b/features/pool/pool.go
@@ -56,15 +56,16 @@ func (p *pool) message(message *protogen.Message) {
 		if field.Desc.IsList() {
 			switch field.Desc.Kind() {
 			case protoreflect.MessageKind, protoreflect.GroupKind:
+				p.P(`for _, mm := range m.`, fieldName, `{`)
 				if p.ShouldPool(field.Message) {
-					p.P(`for _, mm := range m.`, fieldName, `{`)
 					p.P(`mm.ResetVT()`)
-					p.P(`}`)
+				} else {
+					p.P(`mm.Reset()`)
 				}
-			default:
-				p.P(fmt.Sprintf("f%d", len(saved)), ` := m.`, fieldName, `[:0]`)
-				saved = append(saved, field)
+				p.P(`}`)
 			}
+			p.P(fmt.Sprintf("f%d", len(saved)), ` := m.`, fieldName, `[:0]`)
+			saved = append(saved, field)
 		} else {
 			switch field.Desc.Kind() {
 			case protoreflect.MessageKind, protoreflect.GroupKind:

--- a/testproto/pool/pool_test.go
+++ b/testproto/pool/pool_test.go
@@ -85,5 +85,4 @@ func Test_Pool_slice_recreation(t *testing.T) {
 	assert.Nil(t, req.Sl[0].C)
 	assert.Zero(t, req.Sl[0].E)
 	assert.Zero(t, req.Sl[0].F)
-
 }

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -689,7 +689,12 @@ var vtprotoPool_Test2 = sync.Pool{
 }
 
 func (m *Test2) ResetVT() {
+	for _, mm := range m.Sl {
+		mm.Reset()
+	}
+	f0 := m.Sl[:0]
 	m.Reset()
+	m.Sl = f0
 }
 func (m *Test2) ReturnToVTPool() {
 	if m != nil {


### PR DESCRIPTION
When using Pooling and so ResetVT we definitively want to reuse slices.

However a bug was recently discovered where it would not zeroed slice items. 

https://github.com/planetscale/vtprotobuf/pull/35 introduces a fixes by simply removing slice recycling which I think makes pooling a bit less interesting.

This PR rollback #35 and takes another approach that actually Reset the member even if ResetVT is not available because the feature pool is deactivate for that type.

I can't generate anything unfortunately I don't have the protoc version I'd appreciate help for re-generating those.