### PR TITLE
fix: check oneof on syntetic

### DIFF
--- a/features/pool/pool.go
+++ b/features/pool/pool.go
@@ -68,7 +68,7 @@ func (p *pool) message(message *protogen.Message) {
 			}
 			p.P(fmt.Sprintf("f%d", len(saved)), ` := m.`, fieldName, `[:0]`)
 			saved = append(saved, field)
-		} else if field.Oneof != nil {
+		} else if field.Oneof != nil && !field.Oneof.Desc.IsSynthetic() {
 			if p.ShouldPool(field.Message) {
 				p.P(`if oneof, ok := m.`, field.Oneof.GoName, `.(*`, field.GoIdent, `); ok {`)
 				p.P(`oneof.`, fieldName, `.ReturnToVTPool()`)

--- a/testproto/pool/pool.pb.go
+++ b/testproto/pool/pool.pb.go
@@ -21,19 +21,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type OptionalMessage struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *OptionalMessage) Reset() {
+	*x = OptionalMessage{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pool_pool_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *OptionalMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OptionalMessage) ProtoMessage() {}
+
+func (x *OptionalMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_pool_pool_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OptionalMessage.ProtoReflect.Descriptor instead.
+func (*OptionalMessage) Descriptor() ([]byte, []int) {
+	return file_pool_pool_proto_rawDescGZIP(), []int{0}
+}
+
 type MemoryPoolExtension struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Foo1 string `protobuf:"bytes,1,opt,name=foo1,proto3" json:"foo1,omitempty"`
-	Foo2 uint64 `protobuf:"varint,2,opt,name=foo2,proto3" json:"foo2,omitempty"`
+	Foo1 string           `protobuf:"bytes,1,opt,name=foo1,proto3" json:"foo1,omitempty"`
+	Foo2 uint64           `protobuf:"varint,2,opt,name=foo2,proto3" json:"foo2,omitempty"`
+	Foo3 *OptionalMessage `protobuf:"bytes,3,opt,name=foo3,proto3,oneof" json:"foo3,omitempty"`
 }
 
 func (x *MemoryPoolExtension) Reset() {
 	*x = MemoryPoolExtension{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pool_pool_proto_msgTypes[0]
+		mi := &file_pool_pool_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -46,7 +85,7 @@ func (x *MemoryPoolExtension) String() string {
 func (*MemoryPoolExtension) ProtoMessage() {}
 
 func (x *MemoryPoolExtension) ProtoReflect() protoreflect.Message {
-	mi := &file_pool_pool_proto_msgTypes[0]
+	mi := &file_pool_pool_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59,7 +98,7 @@ func (x *MemoryPoolExtension) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemoryPoolExtension.ProtoReflect.Descriptor instead.
 func (*MemoryPoolExtension) Descriptor() ([]byte, []int) {
-	return file_pool_pool_proto_rawDescGZIP(), []int{0}
+	return file_pool_pool_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *MemoryPoolExtension) GetFoo1() string {
@@ -76,6 +115,13 @@ func (x *MemoryPoolExtension) GetFoo2() uint64 {
 	return 0
 }
 
+func (x *MemoryPoolExtension) GetFoo3() *OptionalMessage {
+	if x != nil {
+		return x.Foo3
+	}
+	return nil
+}
+
 var File_pool_pool_proto protoreflect.FileDescriptor
 
 var file_pool_pool_proto_rawDesc = []byte{
@@ -83,13 +129,18 @@ var file_pool_pool_proto_rawDesc = []byte{
 	0x6f, 0x1a, 0x33, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x6c,
 	0x61, 0x6e, 0x65, 0x74, 0x73, 0x63, 0x61, 0x6c, 0x65, 0x2f, 0x76, 0x74, 0x70, 0x72, 0x6f, 0x74,
 	0x6f, 0x62, 0x75, 0x66, 0x2f, 0x76, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x78, 0x74,
-	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x43, 0x0a, 0x13, 0x4d, 0x65, 0x6d, 0x6f, 0x72, 0x79,
-	0x50, 0x6f, 0x6f, 0x6c, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x12, 0x0a,
-	0x04, 0x66, 0x6f, 0x6f, 0x31, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x66, 0x6f, 0x6f,
-	0x31, 0x12, 0x12, 0x0a, 0x04, 0x66, 0x6f, 0x6f, 0x32, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52,
-	0x04, 0x66, 0x6f, 0x6f, 0x32, 0x3a, 0x04, 0xa8, 0xa6, 0x1f, 0x01, 0x42, 0x10, 0x5a, 0x0e, 0x74,
-	0x65, 0x73, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x70, 0x6f, 0x6f, 0x6c, 0x62, 0x06, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x17, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+	0x61, 0x6c, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x3a, 0x04, 0xa8, 0xa6, 0x1f, 0x01, 0x22,
+	0x77, 0x0a, 0x13, 0x4d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x50, 0x6f, 0x6f, 0x6c, 0x45, 0x78, 0x74,
+	0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x12, 0x0a, 0x04, 0x66, 0x6f, 0x6f, 0x31, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x66, 0x6f, 0x6f, 0x31, 0x12, 0x12, 0x0a, 0x04, 0x66, 0x6f,
+	0x6f, 0x32, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x66, 0x6f, 0x6f, 0x32, 0x12, 0x29,
+	0x0a, 0x04, 0x66, 0x6f, 0x6f, 0x33, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x4f,
+	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x48, 0x00,
+	0x52, 0x04, 0x66, 0x6f, 0x6f, 0x33, 0x88, 0x01, 0x01, 0x3a, 0x04, 0xa8, 0xa6, 0x1f, 0x01, 0x42,
+	0x07, 0x0a, 0x05, 0x5f, 0x66, 0x6f, 0x6f, 0x33, 0x42, 0x10, 0x5a, 0x0e, 0x74, 0x65, 0x73, 0x74,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x70, 0x6f, 0x6f, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var (
@@ -104,16 +155,18 @@ func file_pool_pool_proto_rawDescGZIP() []byte {
 	return file_pool_pool_proto_rawDescData
 }
 
-var file_pool_pool_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_pool_pool_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_pool_pool_proto_goTypes = []interface{}{
-	(*MemoryPoolExtension)(nil), // 0: MemoryPoolExtension
+	(*OptionalMessage)(nil),     // 0: OptionalMessage
+	(*MemoryPoolExtension)(nil), // 1: MemoryPoolExtension
 }
 var file_pool_pool_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: MemoryPoolExtension.foo3:type_name -> OptionalMessage
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_pool_pool_proto_init() }
@@ -123,6 +176,18 @@ func file_pool_pool_proto_init() {
 	}
 	if !protoimpl.UnsafeEnabled {
 		file_pool_pool_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*OptionalMessage); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pool_pool_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MemoryPoolExtension); i {
 			case 0:
 				return &v.state
@@ -135,13 +200,14 @@ func file_pool_pool_proto_init() {
 			}
 		}
 	}
+	file_pool_pool_proto_msgTypes[1].OneofWrappers = []interface{}{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_pool_pool_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/testproto/pool/pool.proto
+++ b/testproto/pool/pool.proto
@@ -3,8 +3,13 @@ option go_package = "testproto/pool";
 
 import "github.com/planetscale/vtprotobuf/vtproto/ext.proto";
 
+message OptionalMessage{
+  option (vtproto.mempool) = true;
+}
+
 message MemoryPoolExtension {
   option (vtproto.mempool) = true;
   string foo1 = 1;
   uint64 foo2 = 2;
+  optional OptionalMessage foo3 = 3;
 }

--- a/testproto/pool/pool_test.go
+++ b/testproto/pool/pool_test.go
@@ -1,12 +1,13 @@
 package pool
 
 import (
-	"google.golang.org/protobuf/proto"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/proto"
 )
 
 func Test_Pool_slice_data_override(t *testing.T) {

--- a/testproto/pool/pool_test.go
+++ b/testproto/pool/pool_test.go
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	"google.golang.org/protobuf/proto"
 	"log"
 	"testing"
 
@@ -162,4 +163,25 @@ func Test_Pool_Oneof(t *testing.T) {
 	t8 := OneofTestFromVTPool()
 	require.NoError(t, t8.UnmarshalVT(t4Bytes))
 	require.Equal(t, &t4, &t8)
+}
+
+func Test_Pool_Optional(t *testing.T) {
+	m := &MemoryPoolExtension{
+		Foo1: "foo1",
+		Foo2: 123,
+		Foo3: &OptionalMessage{},
+	}
+
+	mBytes, err := m.MarshalVT()
+	require.NoError(t, err)
+
+	mUnmarshal := &MemoryPoolExtension{}
+	err = proto.Unmarshal(mBytes, mUnmarshal)
+	require.NoError(t, err)
+
+	require.True(t, m.EqualVT(mUnmarshal))
+
+	m.ReturnToVTPool()
+	mFromPool := MemoryPoolExtensionFromVTPool()
+	require.True(t, mFromPool.EqualVT(&MemoryPoolExtension{}))
 }

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -21,6 +21,22 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *OptionalMessage) CloneVT() *OptionalMessage {
+	if m == nil {
+		return (*OptionalMessage)(nil)
+	}
+	r := OptionalMessageFromVTPool()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *OptionalMessage) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *MemoryPoolExtension) CloneVT() *MemoryPoolExtension {
 	if m == nil {
 		return (*MemoryPoolExtension)(nil)
@@ -28,6 +44,7 @@ func (m *MemoryPoolExtension) CloneVT() *MemoryPoolExtension {
 	r := MemoryPoolExtensionFromVTPool()
 	r.Foo1 = m.Foo1
 	r.Foo2 = m.Foo2
+	r.Foo3 = m.Foo3.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -39,6 +56,22 @@ func (m *MemoryPoolExtension) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (this *OptionalMessage) EqualVT(that *OptionalMessage) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *OptionalMessage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*OptionalMessage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
 	if this == that {
 		return true
@@ -51,6 +84,9 @@ func (this *MemoryPoolExtension) EqualVT(that *MemoryPoolExtension) bool {
 	if this.Foo2 != that.Foo2 {
 		return false
 	}
+	if !this.Foo3.EqualVT(that.Foo3) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -61,6 +97,39 @@ func (this *MemoryPoolExtension) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (m *OptionalMessage) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalMessage) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *OptionalMessage) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *MemoryPoolExtension) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -91,6 +160,16 @@ func (m *MemoryPoolExtension) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Foo3 != nil {
+		size, err := m.Foo3.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.Foo2 != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.Foo2))
 		i--
@@ -117,6 +196,39 @@ func encodeVarint(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *OptionalMessage) MarshalVTStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalMessage) MarshalToVTStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStrict(dAtA[:size])
+}
+
+func (m *OptionalMessage) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *MemoryPoolExtension) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -147,6 +259,16 @@ func (m *MemoryPoolExtension) MarshalToSizedBufferVTStrict(dAtA []byte) (int, er
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Foo3 != nil {
+		size, err := m.Foo3.MarshalToSizedBufferVTStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.Foo2 != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.Foo2))
 		i--
@@ -162,6 +284,27 @@ func (m *MemoryPoolExtension) MarshalToSizedBufferVTStrict(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_OptionalMessage = sync.Pool{
+	New: func() interface{} {
+		return &OptionalMessage{}
+	},
+}
+
+func (m *OptionalMessage) ResetVT() {
+	if m != nil {
+		m.Reset()
+	}
+}
+func (m *OptionalMessage) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_OptionalMessage.Put(m)
+	}
+}
+func OptionalMessageFromVTPool() *OptionalMessage {
+	return vtprotoPool_OptionalMessage.Get().(*OptionalMessage)
+}
+
 var vtprotoPool_MemoryPoolExtension = sync.Pool{
 	New: func() interface{} {
 		return &MemoryPoolExtension{}
@@ -170,6 +313,7 @@ var vtprotoPool_MemoryPoolExtension = sync.Pool{
 
 func (m *MemoryPoolExtension) ResetVT() {
 	if m != nil {
+		m.Foo3.ReturnToVTPool()
 		m.Reset()
 	}
 }
@@ -182,6 +326,16 @@ func (m *MemoryPoolExtension) ReturnToVTPool() {
 func MemoryPoolExtensionFromVTPool() *MemoryPoolExtension {
 	return vtprotoPool_MemoryPoolExtension.Get().(*MemoryPoolExtension)
 }
+func (m *OptionalMessage) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *MemoryPoolExtension) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -195,6 +349,10 @@ func (m *MemoryPoolExtension) SizeVT() (n int) {
 	if m.Foo2 != 0 {
 		n += 1 + sov(uint64(m.Foo2))
 	}
+	if m.Foo3 != nil {
+		l = m.Foo3.SizeVT()
+		n += 1 + l + sov(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -204,6 +362,57 @@ func sov(x uint64) (n int) {
 }
 func soz(x uint64) (n int) {
 	return sov(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *OptionalMessage) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OptionalMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OptionalMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *MemoryPoolExtension) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
@@ -285,6 +494,42 @@ func (m *MemoryPoolExtension) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Foo3", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Foo3 == nil {
+				m.Foo3 = OptionalMessageFromVTPool()
+			}
+			if err := m.Foo3.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])
@@ -393,6 +638,57 @@ var (
 	ErrUnexpectedEndOfGroup = fmt.Errorf("proto: unexpected end of group")
 )
 
+func (m *OptionalMessage) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OptionalMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OptionalMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *MemoryPoolExtension) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -473,6 +769,42 @@ func (m *MemoryPoolExtension) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Foo3", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Foo3 == nil {
+				m.Foo3 = OptionalMessageFromVTPool()
+			}
+			if err := m.Foo3.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])


### PR DESCRIPTION
During `optional` fields internally represents as `oneof` ResetVT generates broken code for messages with `optional` messages.

Append checks on `field.Oneof.Desc.IsSynthetic()` to determine if field is real `oneof`

Closes #110 