### PR TITLE
Support stable marshaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 _vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ The following features can be generated:
 
     - `func (p *YourProto) MarshalToSizedBufferVTStrict(data []byte) (int, error)`: this function behaves like `MarshalToSizedBufferVT`, except fields are marshalled in a strict order by field's numbers they were declared in .proto file.
 
+- `marshal_stable`: generate the following help methods
+
+    - `func (p *YourProto) MarshalVTStable() ([]byte, error)`: this function behaves like `MarshalVT`, except the maps are marshalled with the stable order to provide the deterministic results.
+
+    - `func (p *YourProto) MarshalToVTStable(data []byte) (int, error)`: this function behaves like `MarshalToVT`, except the maps are marshalled with the stable order to provide the deterministic results.
+
+    - `func (p *YourProto) MarshalToSizedBufferVTStable(data []byte) (int, error)`: this function behaves like `MarshalToSizedBufferVT`, except the maps are marshalled with the stable order to provide the deterministic results.
 
 - `unmarshal`: generates a `func (p *YourProto) UnmarshalVT(data []byte)` that behaves similarly to calling `proto.Unmarshal(data, p)` on the message, except the unmarshalling is performed by unrolled codegen without using reflection and allocating as little memory as possible. If the receiver `p` is **not** fully zeroed-out, the unmarshal call will actually behave like `proto.Merge(data, p)`. This is because the `proto.Unmarshal` in the ProtoBuf API is implemented by resetting the destination message and then calling `proto.Merge` on it. To ensure proper `Unmarshal` semantics, ensure you've called `proto.Reset` on your message before calling `UnmarshalVT`, or that your message has been newly allocated.
 

--- a/conformance/internal/conformance/conformance_vtproto.pb.go
+++ b/conformance/internal/conformance/conformance_vtproto.pb.go
@@ -914,6 +914,820 @@ func (m *JspbEncodingConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *FailureSet) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FailureSet) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *FailureSet) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Failure) > 0 {
+		for iNdEx := len(m.Failure) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Failure[iNdEx])
+			copy(dAtA[i:], m.Failure[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Failure[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceRequest) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ConformanceRequest) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceRequest) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Payload.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m.PrintUnknownFields {
+		i--
+		if m.PrintUnknownFields {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.JspbEncodingOptions != nil {
+		size, err := m.JspbEncodingOptions.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.TestCategory != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TestCategory))
+		i--
+		dAtA[i] = 0x28
+	}
+	if len(m.MessageType) > 0 {
+		i -= len(m.MessageType)
+		copy(dAtA[i:], m.MessageType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MessageType)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.RequestedOutputFormat != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RequestedOutputFormat))
+		i--
+		dAtA[i] = 0x18
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceRequest_ProtobufPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceRequest_ProtobufPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ProtobufPayload)
+	copy(dAtA[i:], m.ProtobufPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProtobufPayload)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_JsonPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceRequest_JsonPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JsonPayload)
+	copy(dAtA[i:], m.JsonPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JsonPayload)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_JspbPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceRequest_JspbPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JspbPayload)
+	copy(dAtA[i:], m.JspbPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JspbPayload)))
+	i--
+	dAtA[i] = 0x3a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_TextPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceRequest_TextPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.TextPayload)
+	copy(dAtA[i:], m.TextPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TextPayload)))
+	i--
+	dAtA[i] = 0x42
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ConformanceResponse) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Result.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceResponse_ParseError) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_ParseError) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ParseError)
+	copy(dAtA[i:], m.ParseError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ParseError)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_RuntimeError) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_RuntimeError) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.RuntimeError)
+	copy(dAtA[i:], m.RuntimeError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RuntimeError)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_ProtobufPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_ProtobufPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ProtobufPayload)
+	copy(dAtA[i:], m.ProtobufPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProtobufPayload)))
+	i--
+	dAtA[i] = 0x1a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_JsonPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_JsonPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JsonPayload)
+	copy(dAtA[i:], m.JsonPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JsonPayload)))
+	i--
+	dAtA[i] = 0x22
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_Skipped) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_Skipped) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.Skipped)
+	copy(dAtA[i:], m.Skipped)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Skipped)))
+	i--
+	dAtA[i] = 0x2a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_SerializeError) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_SerializeError) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.SerializeError)
+	copy(dAtA[i:], m.SerializeError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SerializeError)))
+	i--
+	dAtA[i] = 0x32
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_JspbPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_JspbPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JspbPayload)
+	copy(dAtA[i:], m.JspbPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JspbPayload)))
+	i--
+	dAtA[i] = 0x3a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_TextPayload) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ConformanceResponse_TextPayload) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.TextPayload)
+	copy(dAtA[i:], m.TextPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TextPayload)))
+	i--
+	dAtA[i] = 0x42
+	return len(dAtA) - i, nil
+}
+func (m *JspbEncodingConfig) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *JspbEncodingConfig) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *JspbEncodingConfig) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.UseJspbArrayAnyFormat {
+		i--
+		if m.UseJspbArrayAnyFormat {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FailureSet) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FailureSet) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *FailureSet) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Failure) > 0 {
+		for iNdEx := len(m.Failure) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Failure[iNdEx])
+			copy(dAtA[i:], m.Failure[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Failure[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceRequest) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ConformanceRequest) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceRequest) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.PrintUnknownFields {
+		i--
+		if m.PrintUnknownFields {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
+	if msg, ok := m.Payload.(*ConformanceRequest_TextPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Payload.(*ConformanceRequest_JspbPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m.JspbEncodingOptions != nil {
+		size, err := m.JspbEncodingOptions.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.TestCategory != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TestCategory))
+		i--
+		dAtA[i] = 0x28
+	}
+	if len(m.MessageType) > 0 {
+		i -= len(m.MessageType)
+		copy(dAtA[i:], m.MessageType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MessageType)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.RequestedOutputFormat != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RequestedOutputFormat))
+		i--
+		dAtA[i] = 0x18
+	}
+	if msg, ok := m.Payload.(*ConformanceRequest_JsonPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Payload.(*ConformanceRequest_ProtobufPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceRequest_ProtobufPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceRequest_ProtobufPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ProtobufPayload)
+	copy(dAtA[i:], m.ProtobufPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProtobufPayload)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_JsonPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceRequest_JsonPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JsonPayload)
+	copy(dAtA[i:], m.JsonPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JsonPayload)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_JspbPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceRequest_JspbPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JspbPayload)
+	copy(dAtA[i:], m.JspbPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JspbPayload)))
+	i--
+	dAtA[i] = 0x3a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceRequest_TextPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceRequest_TextPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.TextPayload)
+	copy(dAtA[i:], m.TextPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TextPayload)))
+	i--
+	dAtA[i] = 0x42
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ConformanceResponse) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_TextPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_JspbPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_SerializeError); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_Skipped); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_JsonPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_ProtobufPayload); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_RuntimeError); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Result.(*ConformanceResponse_ParseError); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ConformanceResponse_ParseError) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_ParseError) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ParseError)
+	copy(dAtA[i:], m.ParseError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ParseError)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_RuntimeError) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_RuntimeError) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.RuntimeError)
+	copy(dAtA[i:], m.RuntimeError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RuntimeError)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_ProtobufPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_ProtobufPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.ProtobufPayload)
+	copy(dAtA[i:], m.ProtobufPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProtobufPayload)))
+	i--
+	dAtA[i] = 0x1a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_JsonPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_JsonPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JsonPayload)
+	copy(dAtA[i:], m.JsonPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JsonPayload)))
+	i--
+	dAtA[i] = 0x22
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_Skipped) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_Skipped) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.Skipped)
+	copy(dAtA[i:], m.Skipped)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Skipped)))
+	i--
+	dAtA[i] = 0x2a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_SerializeError) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_SerializeError) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.SerializeError)
+	copy(dAtA[i:], m.SerializeError)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SerializeError)))
+	i--
+	dAtA[i] = 0x32
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_JspbPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_JspbPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.JspbPayload)
+	copy(dAtA[i:], m.JspbPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.JspbPayload)))
+	i--
+	dAtA[i] = 0x3a
+	return len(dAtA) - i, nil
+}
+func (m *ConformanceResponse_TextPayload) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ConformanceResponse_TextPayload) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.TextPayload)
+	copy(dAtA[i:], m.TextPayload)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TextPayload)))
+	i--
+	dAtA[i] = 0x42
+	return len(dAtA) - i, nil
+}
+func (m *JspbEncodingConfig) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *JspbEncodingConfig) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *JspbEncodingConfig) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.UseJspbArrayAnyFormat {
+		i--
+		if m.UseJspbArrayAnyFormat {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *FailureSet) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto2_vtproto.pb.go
@@ -12,6 +12,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	math "math"
+	sort "sort"
 	unsafe "unsafe"
 )
 
@@ -4288,6 +4289,4444 @@ func (m *OneStringProto2) MarshalToVT(dAtA []byte) (int, error) {
 }
 
 func (m *OneStringProto2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Data != nil {
+		i -= len(*m.Data)
+		copy(dAtA[i:], *m.Data)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.Data)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Corecursive != nil {
+		size, err := m.Corecursive.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.A != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_Data) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_Data) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_Data) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.GroupUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.GroupUint32))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.GroupInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.GroupInt32))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd0
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Str != nil {
+		i -= len(*m.Str)
+		copy(dAtA[i:], *m.Str)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.Str)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.I != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.I))
+		i--
+		dAtA[i] = 0x48
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.OneofField.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m.FieldName18__ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName18__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.FieldName17__ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName17__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Field__Name16 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field__Name16))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Field_Name15 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name15))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.X_FieldName14 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.X_FieldName14))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.XFieldName13 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.XFieldName13))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.FIELDName12 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FIELDName12))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.FIELD_NAME11 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FIELD_NAME11))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.Field_Name10 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name10))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd0
+	}
+	if m.Field_Name9 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name9))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc8
+	}
+	if m.FieldName8 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName8))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc0
+	}
+	if m.FieldName7 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName7))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.Field_0Name6 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_0Name6))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.Field0Name5 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field0Name5))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.Field_Name4_ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name4_))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.XFieldName3 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.XFieldName3))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.FieldName2 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName2))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.Fieldname1 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Fieldname1))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.DefaultBytes != nil {
+		i -= len(m.DefaultBytes)
+		copy(dAtA[i:], m.DefaultBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DefaultBytes)))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.DefaultString != nil {
+		i -= len(*m.DefaultString)
+		copy(dAtA[i:], *m.DefaultString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.DefaultString)))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.DefaultBool != nil {
+		i--
+		if *m.DefaultBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.DefaultDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.DefaultDouble))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xe1
+	}
+	if m.DefaultFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.DefaultFloat))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xdd
+	}
+	if m.DefaultSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.DefaultSfixed64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xd1
+	}
+	if m.DefaultSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.DefaultSfixed32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xcd
+	}
+	if m.DefaultFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.DefaultFixed64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xc1
+	}
+	if m.DefaultFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.DefaultFixed32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xbd
+	}
+	if m.DefaultSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.DefaultSint64)<<1)^uint64((*m.DefaultSint64>>63))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.DefaultSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.DefaultSint32)<<1)^uint32((*m.DefaultSint32>>31))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.DefaultUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultUint64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.DefaultUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultUint32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.DefaultInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultInt64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.DefaultInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultInt32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Data != nil {
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xcc
+		size, err := m.Data.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xcb
+	}
+	if len(m.UnpackedNestedEnum) > 0 {
+		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xb0
+		}
+	}
+	if len(m.UnpackedBool) > 0 {
+		for iNdEx := len(m.UnpackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.UnpackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa8
+		}
+	}
+	if len(m.UnpackedDouble) > 0 {
+		for iNdEx := len(m.UnpackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.UnpackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa1
+		}
+	}
+	if len(m.UnpackedFloat) > 0 {
+		for iNdEx := len(m.UnpackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.UnpackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x9d
+		}
+	}
+	if len(m.UnpackedSfixed64) > 0 {
+		for iNdEx := len(m.UnpackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x91
+		}
+	}
+	if len(m.UnpackedSfixed32) > 0 {
+		for iNdEx := len(m.UnpackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x8d
+		}
+	}
+	if len(m.UnpackedFixed64) > 0 {
+		for iNdEx := len(m.UnpackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x81
+		}
+	}
+	if len(m.UnpackedFixed32) > 0 {
+		for iNdEx := len(m.UnpackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xfd
+		}
+	}
+	if len(m.UnpackedSint64) > 0 {
+		for iNdEx := len(m.UnpackedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x3 := (uint64(m.UnpackedSint64[iNdEx]) << 1) ^ uint64((m.UnpackedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x3))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xf0
+		}
+	}
+	if len(m.UnpackedSint32) > 0 {
+		for iNdEx := len(m.UnpackedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.UnpackedSint32[iNdEx]) << 1) ^ uint32((m.UnpackedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe8
+		}
+	}
+	if len(m.UnpackedUint64) > 0 {
+		for iNdEx := len(m.UnpackedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe0
+		}
+	}
+	if len(m.UnpackedUint32) > 0 {
+		for iNdEx := len(m.UnpackedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.UnpackedInt64) > 0 {
+		for iNdEx := len(m.UnpackedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd0
+		}
+	}
+	if len(m.UnpackedInt32) > 0 {
+		for iNdEx := len(m.UnpackedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xc8
+		}
+	}
+	if len(m.PackedNestedEnum) > 0 {
+		var pksize6 int
+		for _, num := range m.PackedNestedEnum {
+			pksize6 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize6
+		j5 := i
+		for _, num1 := range m.PackedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j5] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j5++
+			}
+			dAtA[j5] = uint8(num)
+			j5++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize6))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.PackedBool) > 0 {
+		for iNdEx := len(m.PackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedBool)))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.PackedDouble) > 0 {
+		for iNdEx := len(m.PackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f7 := math.Float64bits(float64(m.PackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f7))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedDouble)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.PackedFloat) > 0 {
+		for iNdEx := len(m.PackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f8 := math.Float32bits(float32(m.PackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f8))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFloat)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.PackedSfixed64) > 0 {
+		for iNdEx := len(m.PackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.PackedSfixed32) > 0 {
+		for iNdEx := len(m.PackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.PackedFixed64) > 0 {
+		for iNdEx := len(m.PackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.PackedFixed32) > 0 {
+		for iNdEx := len(m.PackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.PackedSint64) > 0 {
+		var pksize10 int
+		for _, num := range m.PackedSint64 {
+			pksize10 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize10
+		j9 := i
+		for _, num := range m.PackedSint64 {
+			x11 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x11 >= 1<<7 {
+				dAtA[j9] = uint8(uint64(x11)&0x7f | 0x80)
+				j9++
+				x11 >>= 7
+			}
+			dAtA[j9] = uint8(x11)
+			j9++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize10))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.PackedSint32) > 0 {
+		var pksize13 int
+		for _, num := range m.PackedSint32 {
+			pksize13 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize13
+		j12 := i
+		for _, num := range m.PackedSint32 {
+			x14 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x14 >= 1<<7 {
+				dAtA[j12] = uint8(uint64(x14)&0x7f | 0x80)
+				j12++
+				x14 >>= 7
+			}
+			dAtA[j12] = uint8(x14)
+			j12++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize13))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xfa
+	}
+	if len(m.PackedUint64) > 0 {
+		var pksize16 int
+		for _, num := range m.PackedUint64 {
+			pksize16 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize16
+		j15 := i
+		for _, num := range m.PackedUint64 {
+			for num >= 1<<7 {
+				dAtA[j15] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j15++
+			}
+			dAtA[j15] = uint8(num)
+			j15++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize16))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xf2
+	}
+	if len(m.PackedUint32) > 0 {
+		var pksize18 int
+		for _, num := range m.PackedUint32 {
+			pksize18 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize18
+		j17 := i
+		for _, num := range m.PackedUint32 {
+			for num >= 1<<7 {
+				dAtA[j17] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j17++
+			}
+			dAtA[j17] = uint8(num)
+			j17++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize18))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.PackedInt64) > 0 {
+		var pksize20 int
+		for _, num := range m.PackedInt64 {
+			pksize20 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize20
+		j19 := i
+		for _, num1 := range m.PackedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j19] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j19++
+			}
+			dAtA[j19] = uint8(num)
+			j19++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize20))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xe2
+	}
+	if len(m.PackedInt32) > 0 {
+		var pksize22 int
+		for _, num := range m.PackedInt32 {
+			pksize22 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize22
+		j21 := i
+		for _, num1 := range m.PackedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j21] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j21++
+			}
+			dAtA[j21] = uint8(num)
+			j21++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize22))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.MapStringForeignEnum) > 0 {
+		keysForMapStringForeignEnum := make([]string, 0, len(m.MapStringForeignEnum))
+		for k := range m.MapStringForeignEnum {
+			keysForMapStringForeignEnum = append(keysForMapStringForeignEnum, string(k))
+		}
+		sort.Slice(keysForMapStringForeignEnum, func(i, j int) bool {
+			return keysForMapStringForeignEnum[i] < keysForMapStringForeignEnum[j]
+		})
+		for iNdEx := len(keysForMapStringForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignEnum[string(keysForMapStringForeignEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringForeignEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapStringNestedEnum) > 0 {
+		keysForMapStringNestedEnum := make([]string, 0, len(m.MapStringNestedEnum))
+		for k := range m.MapStringNestedEnum {
+			keysForMapStringNestedEnum = append(keysForMapStringNestedEnum, string(k))
+		}
+		sort.Slice(keysForMapStringNestedEnum, func(i, j int) bool {
+			return keysForMapStringNestedEnum[i] < keysForMapStringNestedEnum[j]
+		})
+		for iNdEx := len(keysForMapStringNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedEnum[string(keysForMapStringNestedEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringNestedEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapStringForeignMessage) > 0 {
+		keysForMapStringForeignMessage := make([]string, 0, len(m.MapStringForeignMessage))
+		for k := range m.MapStringForeignMessage {
+			keysForMapStringForeignMessage = append(keysForMapStringForeignMessage, string(k))
+		}
+		sort.Slice(keysForMapStringForeignMessage, func(i, j int) bool {
+			return keysForMapStringForeignMessage[i] < keysForMapStringForeignMessage[j]
+		})
+		for iNdEx := len(keysForMapStringForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignMessage[string(keysForMapStringForeignMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringForeignMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.MapStringNestedMessage) > 0 {
+		keysForMapStringNestedMessage := make([]string, 0, len(m.MapStringNestedMessage))
+		for k := range m.MapStringNestedMessage {
+			keysForMapStringNestedMessage = append(keysForMapStringNestedMessage, string(k))
+		}
+		sort.Slice(keysForMapStringNestedMessage, func(i, j int) bool {
+			return keysForMapStringNestedMessage[i] < keysForMapStringNestedMessage[j]
+		})
+		for iNdEx := len(keysForMapStringNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedMessage[string(keysForMapStringNestedMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringNestedMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.MapStringBytes) > 0 {
+		keysForMapStringBytes := make([]string, 0, len(m.MapStringBytes))
+		for k := range m.MapStringBytes {
+			keysForMapStringBytes = append(keysForMapStringBytes, string(k))
+		}
+		sort.Slice(keysForMapStringBytes, func(i, j int) bool {
+			return keysForMapStringBytes[i] < keysForMapStringBytes[j]
+		})
+		for iNdEx := len(keysForMapStringBytes) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringBytes[string(keysForMapStringBytes[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringBytes[iNdEx])
+			copy(dAtA[i:], keysForMapStringBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringBytes[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.MapStringString) > 0 {
+		keysForMapStringString := make([]string, 0, len(m.MapStringString))
+		for k := range m.MapStringString {
+			keysForMapStringString = append(keysForMapStringString, string(k))
+		}
+		sort.Slice(keysForMapStringString, func(i, j int) bool {
+			return keysForMapStringString[i] < keysForMapStringString[j]
+		})
+		for iNdEx := len(keysForMapStringString) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringString[string(keysForMapStringString[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringString[iNdEx])
+			copy(dAtA[i:], keysForMapStringString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringString[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.MapBoolBool) > 0 {
+		for k := range m.MapBoolBool {
+			v := m.MapBoolBool[bool(k)]
+			baseI := i
+			i--
+			if v {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x10
+			i--
+			if k {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.MapInt32Double) > 0 {
+		keysForMapInt32Double := make([]int32, 0, len(m.MapInt32Double))
+		for k := range m.MapInt32Double {
+			keysForMapInt32Double = append(keysForMapInt32Double, int32(k))
+		}
+		sort.Slice(keysForMapInt32Double, func(i, j int) bool {
+			return keysForMapInt32Double[i] < keysForMapInt32Double[j]
+		})
+		for iNdEx := len(keysForMapInt32Double) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Double[int32(keysForMapInt32Double[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(v))))
+			i--
+			dAtA[i] = 0x11
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Double[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if len(m.MapInt32Float) > 0 {
+		keysForMapInt32Float := make([]int32, 0, len(m.MapInt32Float))
+		for k := range m.MapInt32Float {
+			keysForMapInt32Float = append(keysForMapInt32Float, int32(k))
+		}
+		sort.Slice(keysForMapInt32Float, func(i, j int) bool {
+			return keysForMapInt32Float[i] < keysForMapInt32Float[j]
+		})
+		for iNdEx := len(keysForMapInt32Float) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Float[int32(keysForMapInt32Float[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(v))))
+			i--
+			dAtA[i] = 0x15
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Float[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x92
+		}
+	}
+	if len(m.MapSfixed64Sfixed64) > 0 {
+		keysForMapSfixed64Sfixed64 := make([]int64, 0, len(m.MapSfixed64Sfixed64))
+		for k := range m.MapSfixed64Sfixed64 {
+			keysForMapSfixed64Sfixed64 = append(keysForMapSfixed64Sfixed64, int64(k))
+		}
+		sort.Slice(keysForMapSfixed64Sfixed64, func(i, j int) bool {
+			return keysForMapSfixed64Sfixed64[i] < keysForMapSfixed64Sfixed64[j]
+		})
+		for iNdEx := len(keysForMapSfixed64Sfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed64Sfixed64[int64(keysForMapSfixed64Sfixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapSfixed64Sfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.MapSfixed32Sfixed32) > 0 {
+		keysForMapSfixed32Sfixed32 := make([]int32, 0, len(m.MapSfixed32Sfixed32))
+		for k := range m.MapSfixed32Sfixed32 {
+			keysForMapSfixed32Sfixed32 = append(keysForMapSfixed32Sfixed32, int32(k))
+		}
+		sort.Slice(keysForMapSfixed32Sfixed32, func(i, j int) bool {
+			return keysForMapSfixed32Sfixed32[i] < keysForMapSfixed32Sfixed32[j]
+		})
+		for iNdEx := len(keysForMapSfixed32Sfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed32Sfixed32[int32(keysForMapSfixed32Sfixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapSfixed32Sfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.MapFixed64Fixed64) > 0 {
+		keysForMapFixed64Fixed64 := make([]uint64, 0, len(m.MapFixed64Fixed64))
+		for k := range m.MapFixed64Fixed64 {
+			keysForMapFixed64Fixed64 = append(keysForMapFixed64Fixed64, uint64(k))
+		}
+		sort.Slice(keysForMapFixed64Fixed64, func(i, j int) bool {
+			return keysForMapFixed64Fixed64[i] < keysForMapFixed64Fixed64[j]
+		})
+		for iNdEx := len(keysForMapFixed64Fixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed64Fixed64[uint64(keysForMapFixed64Fixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapFixed64Fixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
+	if len(m.MapFixed32Fixed32) > 0 {
+		keysForMapFixed32Fixed32 := make([]uint32, 0, len(m.MapFixed32Fixed32))
+		for k := range m.MapFixed32Fixed32 {
+			keysForMapFixed32Fixed32 = append(keysForMapFixed32Fixed32, uint32(k))
+		}
+		sort.Slice(keysForMapFixed32Fixed32, func(i, j int) bool {
+			return keysForMapFixed32Fixed32[i] < keysForMapFixed32Fixed32[j]
+		})
+		for iNdEx := len(keysForMapFixed32Fixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed32Fixed32[uint32(keysForMapFixed32Fixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapFixed32Fixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xf2
+		}
+	}
+	if len(m.MapSint64Sint64) > 0 {
+		keysForMapSint64Sint64 := make([]int64, 0, len(m.MapSint64Sint64))
+		for k := range m.MapSint64Sint64 {
+			keysForMapSint64Sint64 = append(keysForMapSint64Sint64, int64(k))
+		}
+		sort.Slice(keysForMapSint64Sint64, func(i, j int) bool {
+			return keysForMapSint64Sint64[i] < keysForMapSint64Sint64[j]
+		})
+		for iNdEx := len(keysForMapSint64Sint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint64Sint64[int64(keysForMapSint64Sint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(v)<<1)^uint64((v>>63))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(keysForMapSint64Sint64[iNdEx])<<1)^uint64((keysForMapSint64Sint64[iNdEx]>>63))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.MapSint32Sint32) > 0 {
+		keysForMapSint32Sint32 := make([]int32, 0, len(m.MapSint32Sint32))
+		for k := range m.MapSint32Sint32 {
+			keysForMapSint32Sint32 = append(keysForMapSint32Sint32, int32(k))
+		}
+		sort.Slice(keysForMapSint32Sint32, func(i, j int) bool {
+			return keysForMapSint32Sint32[i] < keysForMapSint32Sint32[j]
+		})
+		for iNdEx := len(keysForMapSint32Sint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint32Sint32[int32(keysForMapSint32Sint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(v)<<1)^uint32((v>>31))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(keysForMapSint32Sint32[iNdEx])<<1)^uint32((keysForMapSint32Sint32[iNdEx]>>31))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.MapUint64Uint64) > 0 {
+		keysForMapUint64Uint64 := make([]uint64, 0, len(m.MapUint64Uint64))
+		for k := range m.MapUint64Uint64 {
+			keysForMapUint64Uint64 = append(keysForMapUint64Uint64, uint64(k))
+		}
+		sort.Slice(keysForMapUint64Uint64, func(i, j int) bool {
+			return keysForMapUint64Uint64[i] < keysForMapUint64Uint64[j]
+		})
+		for iNdEx := len(keysForMapUint64Uint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint64Uint64[uint64(keysForMapUint64Uint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint64Uint64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.MapUint32Uint32) > 0 {
+		keysForMapUint32Uint32 := make([]uint32, 0, len(m.MapUint32Uint32))
+		for k := range m.MapUint32Uint32 {
+			keysForMapUint32Uint32 = append(keysForMapUint32Uint32, uint32(k))
+		}
+		sort.Slice(keysForMapUint32Uint32, func(i, j int) bool {
+			return keysForMapUint32Uint32[i] < keysForMapUint32Uint32[j]
+		})
+		for iNdEx := len(keysForMapUint32Uint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint32Uint32[uint32(keysForMapUint32Uint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint32Uint32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapInt64Int64) > 0 {
+		keysForMapInt64Int64 := make([]int64, 0, len(m.MapInt64Int64))
+		for k := range m.MapInt64Int64 {
+			keysForMapInt64Int64 = append(keysForMapInt64Int64, int64(k))
+		}
+		sort.Slice(keysForMapInt64Int64, func(i, j int) bool {
+			return keysForMapInt64Int64[i] < keysForMapInt64Int64[j]
+		})
+		for iNdEx := len(keysForMapInt64Int64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt64Int64[int64(keysForMapInt64Int64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt64Int64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapInt32Int32) > 0 {
+		keysForMapInt32Int32 := make([]int32, 0, len(m.MapInt32Int32))
+		for k := range m.MapInt32Int32 {
+			keysForMapInt32Int32 = append(keysForMapInt32Int32, int32(k))
+		}
+		sort.Slice(keysForMapInt32Int32, func(i, j int) bool {
+			return keysForMapInt32Int32[i] < keysForMapInt32Int32[j]
+		})
+		for iNdEx := len(keysForMapInt32Int32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Int32[int32(keysForMapInt32Int32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Int32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedCord) > 0 {
+		for iNdEx := len(m.RepeatedCord) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedCord[iNdEx])
+			copy(dAtA[i:], m.RepeatedCord[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedCord[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedStringPiece) > 0 {
+		for iNdEx := len(m.RepeatedStringPiece) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedStringPiece[iNdEx])
+			copy(dAtA[i:], m.RepeatedStringPiece[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedStringPiece[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedForeignEnum) > 0 {
+		for iNdEx := len(m.RepeatedForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedForeignEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xa0
+		}
+	}
+	if len(m.RepeatedNestedEnum) > 0 {
+		for iNdEx := len(m.RepeatedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if len(m.RepeatedForeignMessage) > 0 {
+		for iNdEx := len(m.RepeatedForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedForeignMessage[iNdEx].MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.RepeatedNestedMessage) > 0 {
+		for iNdEx := len(m.RepeatedNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedNestedMessage[iNdEx].MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.RepeatedBytes) > 0 {
+		for iNdEx := len(m.RepeatedBytes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedBytes[iNdEx])
+			copy(dAtA[i:], m.RepeatedBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBytes[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedString) > 0 {
+		for iNdEx := len(m.RepeatedString) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedString[iNdEx])
+			copy(dAtA[i:], m.RepeatedString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedString[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedBool) > 0 {
+		for iNdEx := len(m.RepeatedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.RepeatedDouble) > 0 {
+		for iNdEx := len(m.RepeatedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f23 := math.Float64bits(float64(m.RepeatedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f23))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xd1
+		}
+	}
+	if len(m.RepeatedFloat) > 0 {
+		for iNdEx := len(m.RepeatedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f24 := math.Float32bits(float32(m.RepeatedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f24))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xcd
+		}
+	}
+	if len(m.RepeatedSfixed64) > 0 {
+		for iNdEx := len(m.RepeatedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xc1
+		}
+	}
+	if len(m.RepeatedSfixed32) > 0 {
+		for iNdEx := len(m.RepeatedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xbd
+		}
+	}
+	if len(m.RepeatedFixed64) > 0 {
+		for iNdEx := len(m.RepeatedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xb1
+		}
+	}
+	if len(m.RepeatedFixed32) > 0 {
+		for iNdEx := len(m.RepeatedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xad
+		}
+	}
+	if len(m.RepeatedSint64) > 0 {
+		for iNdEx := len(m.RepeatedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x25 := (uint64(m.RepeatedSint64[iNdEx]) << 1) ^ uint64((m.RepeatedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x25))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xa0
+		}
+	}
+	if len(m.RepeatedSint32) > 0 {
+		for iNdEx := len(m.RepeatedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x26 := (uint32(m.RepeatedSint32[iNdEx]) << 1) ^ uint32((m.RepeatedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x26))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if len(m.RepeatedUint64) > 0 {
+		for iNdEx := len(m.RepeatedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x90
+		}
+	}
+	if len(m.RepeatedUint32) > 0 {
+		for iNdEx := len(m.RepeatedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x88
+		}
+	}
+	if len(m.RepeatedInt64) > 0 {
+		for iNdEx := len(m.RepeatedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x80
+		}
+	}
+	if len(m.RepeatedInt32) > 0 {
+		for iNdEx := len(m.RepeatedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xf8
+		}
+	}
+	if m.RecursiveMessage != nil {
+		size, err := m.RecursiveMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalCord != nil {
+		i -= len(*m.OptionalCord)
+		copy(dAtA[i:], *m.OptionalCord)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalCord)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	if m.OptionalStringPiece != nil {
+		i -= len(*m.OptionalStringPiece)
+		copy(dAtA[i:], *m.OptionalStringPiece)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalStringPiece)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
+	if m.OptionalForeignEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalForeignEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.OptionalNestedEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalNestedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.OptionalForeignMessage != nil {
+		size, err := m.OptionalForeignMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
+	if m.OptionalNestedMessage != nil {
+		size, err := m.OptionalNestedMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.OptionalBytes != nil {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalSint64)<<1)^uint64((*m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalSint32)<<1)^uint32((*m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_OneofUint32) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofUint32) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint32))
+	i--
+	dAtA[i] = 0x6
+	i--
+	dAtA[i] = 0xf8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofNestedMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofNestedMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.OneofNestedMessage != nil {
+		size, err := m.OneofNestedMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7
+		i--
+		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofString) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofString) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofString)
+	copy(dAtA[i:], m.OneofString)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofString)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x8a
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofBytes) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofBytes) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofBytes)
+	copy(dAtA[i:], m.OneofBytes)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofBytes)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x92
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofBool) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofBool) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.OneofBool {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x98
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofUint64) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofUint64) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint64))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xa0
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofFloat) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofFloat) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 4
+	binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OneofFloat))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xad
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofDouble) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofDouble) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OneofDouble))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb1
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofEnum) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofEnum) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofEnum))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb8
+	return len(dAtA) - i, nil
+}
+func (m *ForeignMessageProto2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ForeignMessageProto2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ForeignMessageProto2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.C))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnknownToTestAllTypes) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnknownToTestAllTypes) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnknownToTestAllTypes) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedInt32) > 0 {
+		for iNdEx := len(m.RepeatedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x3f
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.Optionalgroup != nil {
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xe4
+		size, err := m.Optionalgroup.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xe3
+	}
+	if m.NestedMessage != nil {
+		size, err := m.NestedMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xc8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NullHypothesisProto2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NullHypothesisProto2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *NullHypothesisProto2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumOnlyProto2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumOnlyProto2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *EnumOnlyProto2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneStringProto2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneStringProto2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneStringProto2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Data != nil {
+		i -= len(*m.Data)
+		copy(dAtA[i:], *m.Data)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.Data)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_NestedMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Corecursive != nil {
+		size, err := m.Corecursive.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.A != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_Data) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_Data) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_Data) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.GroupUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.GroupUint32))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.GroupInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.GroupInt32))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd0
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrect) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension1) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Str != nil {
+		i -= len(*m.Str)
+		copy(dAtA[i:], *m.Str)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.Str)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_MessageSetCorrectExtension2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.I != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.I))
+		i--
+		dAtA[i] = 0x48
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.FieldName18__ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName18__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.FieldName17__ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName17__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Field__Name16 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field__Name16))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Field_Name15 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name15))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.X_FieldName14 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.X_FieldName14))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.XFieldName13 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.XFieldName13))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.FIELDName12 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FIELDName12))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.FIELD_NAME11 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FIELD_NAME11))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.Field_Name10 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name10))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd0
+	}
+	if m.Field_Name9 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name9))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc8
+	}
+	if m.FieldName8 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName8))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc0
+	}
+	if m.FieldName7 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName7))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.Field_0Name6 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_0Name6))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.Field0Name5 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field0Name5))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.Field_Name4_ != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Field_Name4_))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.XFieldName3 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.XFieldName3))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.FieldName2 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.FieldName2))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.Fieldname1 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.Fieldname1))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.DefaultBytes != nil {
+		i -= len(m.DefaultBytes)
+		copy(dAtA[i:], m.DefaultBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DefaultBytes)))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.DefaultString != nil {
+		i -= len(*m.DefaultString)
+		copy(dAtA[i:], *m.DefaultString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.DefaultString)))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.DefaultBool != nil {
+		i--
+		if *m.DefaultBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.DefaultDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.DefaultDouble))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xe1
+	}
+	if m.DefaultFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.DefaultFloat))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xdd
+	}
+	if m.DefaultSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.DefaultSfixed64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xd1
+	}
+	if m.DefaultSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.DefaultSfixed32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xcd
+	}
+	if m.DefaultFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.DefaultFixed64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xc1
+	}
+	if m.DefaultFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.DefaultFixed32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xbd
+	}
+	if m.DefaultSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.DefaultSint64)<<1)^uint64((*m.DefaultSint64>>63))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.DefaultSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.DefaultSint32)<<1)^uint32((*m.DefaultSint32>>31))))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.DefaultUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultUint64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.DefaultUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultUint32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.DefaultInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultInt64))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.DefaultInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.DefaultInt32))
+		i--
+		dAtA[i] = 0xf
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Data != nil {
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xcc
+		size, err := m.Data.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xcb
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofEnum); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofDouble); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofFloat); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofUint64); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofBool); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofBytes); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofString); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofNestedMessage); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto2_OneofUint32); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if len(m.UnpackedNestedEnum) > 0 {
+		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xb0
+		}
+	}
+	if len(m.UnpackedBool) > 0 {
+		for iNdEx := len(m.UnpackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.UnpackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa8
+		}
+	}
+	if len(m.UnpackedDouble) > 0 {
+		for iNdEx := len(m.UnpackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.UnpackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa1
+		}
+	}
+	if len(m.UnpackedFloat) > 0 {
+		for iNdEx := len(m.UnpackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.UnpackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x9d
+		}
+	}
+	if len(m.UnpackedSfixed64) > 0 {
+		for iNdEx := len(m.UnpackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x91
+		}
+	}
+	if len(m.UnpackedSfixed32) > 0 {
+		for iNdEx := len(m.UnpackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x8d
+		}
+	}
+	if len(m.UnpackedFixed64) > 0 {
+		for iNdEx := len(m.UnpackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x81
+		}
+	}
+	if len(m.UnpackedFixed32) > 0 {
+		for iNdEx := len(m.UnpackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xfd
+		}
+	}
+	if len(m.UnpackedSint64) > 0 {
+		for iNdEx := len(m.UnpackedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x3 := (uint64(m.UnpackedSint64[iNdEx]) << 1) ^ uint64((m.UnpackedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x3))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xf0
+		}
+	}
+	if len(m.UnpackedSint32) > 0 {
+		for iNdEx := len(m.UnpackedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.UnpackedSint32[iNdEx]) << 1) ^ uint32((m.UnpackedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe8
+		}
+	}
+	if len(m.UnpackedUint64) > 0 {
+		for iNdEx := len(m.UnpackedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe0
+		}
+	}
+	if len(m.UnpackedUint32) > 0 {
+		for iNdEx := len(m.UnpackedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.UnpackedInt64) > 0 {
+		for iNdEx := len(m.UnpackedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd0
+		}
+	}
+	if len(m.UnpackedInt32) > 0 {
+		for iNdEx := len(m.UnpackedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xc8
+		}
+	}
+	if len(m.PackedNestedEnum) > 0 {
+		var pksize6 int
+		for _, num := range m.PackedNestedEnum {
+			pksize6 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize6
+		j5 := i
+		for _, num1 := range m.PackedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j5] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j5++
+			}
+			dAtA[j5] = uint8(num)
+			j5++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize6))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.PackedBool) > 0 {
+		for iNdEx := len(m.PackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedBool)))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.PackedDouble) > 0 {
+		for iNdEx := len(m.PackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f7 := math.Float64bits(float64(m.PackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f7))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedDouble)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.PackedFloat) > 0 {
+		for iNdEx := len(m.PackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f8 := math.Float32bits(float32(m.PackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f8))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFloat)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.PackedSfixed64) > 0 {
+		for iNdEx := len(m.PackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.PackedSfixed32) > 0 {
+		for iNdEx := len(m.PackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.PackedFixed64) > 0 {
+		for iNdEx := len(m.PackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.PackedFixed32) > 0 {
+		for iNdEx := len(m.PackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.PackedSint64) > 0 {
+		var pksize10 int
+		for _, num := range m.PackedSint64 {
+			pksize10 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize10
+		j9 := i
+		for _, num := range m.PackedSint64 {
+			x11 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x11 >= 1<<7 {
+				dAtA[j9] = uint8(uint64(x11)&0x7f | 0x80)
+				j9++
+				x11 >>= 7
+			}
+			dAtA[j9] = uint8(x11)
+			j9++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize10))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.PackedSint32) > 0 {
+		var pksize13 int
+		for _, num := range m.PackedSint32 {
+			pksize13 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize13
+		j12 := i
+		for _, num := range m.PackedSint32 {
+			x14 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x14 >= 1<<7 {
+				dAtA[j12] = uint8(uint64(x14)&0x7f | 0x80)
+				j12++
+				x14 >>= 7
+			}
+			dAtA[j12] = uint8(x14)
+			j12++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize13))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xfa
+	}
+	if len(m.PackedUint64) > 0 {
+		var pksize16 int
+		for _, num := range m.PackedUint64 {
+			pksize16 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize16
+		j15 := i
+		for _, num := range m.PackedUint64 {
+			for num >= 1<<7 {
+				dAtA[j15] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j15++
+			}
+			dAtA[j15] = uint8(num)
+			j15++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize16))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xf2
+	}
+	if len(m.PackedUint32) > 0 {
+		var pksize18 int
+		for _, num := range m.PackedUint32 {
+			pksize18 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize18
+		j17 := i
+		for _, num := range m.PackedUint32 {
+			for num >= 1<<7 {
+				dAtA[j17] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j17++
+			}
+			dAtA[j17] = uint8(num)
+			j17++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize18))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.PackedInt64) > 0 {
+		var pksize20 int
+		for _, num := range m.PackedInt64 {
+			pksize20 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize20
+		j19 := i
+		for _, num1 := range m.PackedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j19] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j19++
+			}
+			dAtA[j19] = uint8(num)
+			j19++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize20))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xe2
+	}
+	if len(m.PackedInt32) > 0 {
+		var pksize22 int
+		for _, num := range m.PackedInt32 {
+			pksize22 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize22
+		j21 := i
+		for _, num1 := range m.PackedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j21] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j21++
+			}
+			dAtA[j21] = uint8(num)
+			j21++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize22))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.MapStringForeignEnum) > 0 {
+		keysForMapStringForeignEnum := make([]string, 0, len(m.MapStringForeignEnum))
+		for k := range m.MapStringForeignEnum {
+			keysForMapStringForeignEnum = append(keysForMapStringForeignEnum, string(k))
+		}
+		sort.Slice(keysForMapStringForeignEnum, func(i, j int) bool {
+			return keysForMapStringForeignEnum[i] < keysForMapStringForeignEnum[j]
+		})
+		for iNdEx := len(keysForMapStringForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignEnum[string(keysForMapStringForeignEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringForeignEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapStringNestedEnum) > 0 {
+		keysForMapStringNestedEnum := make([]string, 0, len(m.MapStringNestedEnum))
+		for k := range m.MapStringNestedEnum {
+			keysForMapStringNestedEnum = append(keysForMapStringNestedEnum, string(k))
+		}
+		sort.Slice(keysForMapStringNestedEnum, func(i, j int) bool {
+			return keysForMapStringNestedEnum[i] < keysForMapStringNestedEnum[j]
+		})
+		for iNdEx := len(keysForMapStringNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedEnum[string(keysForMapStringNestedEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringNestedEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapStringForeignMessage) > 0 {
+		keysForMapStringForeignMessage := make([]string, 0, len(m.MapStringForeignMessage))
+		for k := range m.MapStringForeignMessage {
+			keysForMapStringForeignMessage = append(keysForMapStringForeignMessage, string(k))
+		}
+		sort.Slice(keysForMapStringForeignMessage, func(i, j int) bool {
+			return keysForMapStringForeignMessage[i] < keysForMapStringForeignMessage[j]
+		})
+		for iNdEx := len(keysForMapStringForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignMessage[string(keysForMapStringForeignMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringForeignMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.MapStringNestedMessage) > 0 {
+		keysForMapStringNestedMessage := make([]string, 0, len(m.MapStringNestedMessage))
+		for k := range m.MapStringNestedMessage {
+			keysForMapStringNestedMessage = append(keysForMapStringNestedMessage, string(k))
+		}
+		sort.Slice(keysForMapStringNestedMessage, func(i, j int) bool {
+			return keysForMapStringNestedMessage[i] < keysForMapStringNestedMessage[j]
+		})
+		for iNdEx := len(keysForMapStringNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedMessage[string(keysForMapStringNestedMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringNestedMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.MapStringBytes) > 0 {
+		keysForMapStringBytes := make([]string, 0, len(m.MapStringBytes))
+		for k := range m.MapStringBytes {
+			keysForMapStringBytes = append(keysForMapStringBytes, string(k))
+		}
+		sort.Slice(keysForMapStringBytes, func(i, j int) bool {
+			return keysForMapStringBytes[i] < keysForMapStringBytes[j]
+		})
+		for iNdEx := len(keysForMapStringBytes) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringBytes[string(keysForMapStringBytes[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringBytes[iNdEx])
+			copy(dAtA[i:], keysForMapStringBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringBytes[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.MapStringString) > 0 {
+		keysForMapStringString := make([]string, 0, len(m.MapStringString))
+		for k := range m.MapStringString {
+			keysForMapStringString = append(keysForMapStringString, string(k))
+		}
+		sort.Slice(keysForMapStringString, func(i, j int) bool {
+			return keysForMapStringString[i] < keysForMapStringString[j]
+		})
+		for iNdEx := len(keysForMapStringString) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringString[string(keysForMapStringString[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringString[iNdEx])
+			copy(dAtA[i:], keysForMapStringString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringString[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.MapBoolBool) > 0 {
+		for k := range m.MapBoolBool {
+			v := m.MapBoolBool[bool(k)]
+			baseI := i
+			i--
+			if v {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x10
+			i--
+			if k {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.MapInt32Double) > 0 {
+		keysForMapInt32Double := make([]int32, 0, len(m.MapInt32Double))
+		for k := range m.MapInt32Double {
+			keysForMapInt32Double = append(keysForMapInt32Double, int32(k))
+		}
+		sort.Slice(keysForMapInt32Double, func(i, j int) bool {
+			return keysForMapInt32Double[i] < keysForMapInt32Double[j]
+		})
+		for iNdEx := len(keysForMapInt32Double) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Double[int32(keysForMapInt32Double[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(v))))
+			i--
+			dAtA[i] = 0x11
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Double[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if len(m.MapInt32Float) > 0 {
+		keysForMapInt32Float := make([]int32, 0, len(m.MapInt32Float))
+		for k := range m.MapInt32Float {
+			keysForMapInt32Float = append(keysForMapInt32Float, int32(k))
+		}
+		sort.Slice(keysForMapInt32Float, func(i, j int) bool {
+			return keysForMapInt32Float[i] < keysForMapInt32Float[j]
+		})
+		for iNdEx := len(keysForMapInt32Float) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Float[int32(keysForMapInt32Float[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(v))))
+			i--
+			dAtA[i] = 0x15
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Float[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x92
+		}
+	}
+	if len(m.MapSfixed64Sfixed64) > 0 {
+		keysForMapSfixed64Sfixed64 := make([]int64, 0, len(m.MapSfixed64Sfixed64))
+		for k := range m.MapSfixed64Sfixed64 {
+			keysForMapSfixed64Sfixed64 = append(keysForMapSfixed64Sfixed64, int64(k))
+		}
+		sort.Slice(keysForMapSfixed64Sfixed64, func(i, j int) bool {
+			return keysForMapSfixed64Sfixed64[i] < keysForMapSfixed64Sfixed64[j]
+		})
+		for iNdEx := len(keysForMapSfixed64Sfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed64Sfixed64[int64(keysForMapSfixed64Sfixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapSfixed64Sfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.MapSfixed32Sfixed32) > 0 {
+		keysForMapSfixed32Sfixed32 := make([]int32, 0, len(m.MapSfixed32Sfixed32))
+		for k := range m.MapSfixed32Sfixed32 {
+			keysForMapSfixed32Sfixed32 = append(keysForMapSfixed32Sfixed32, int32(k))
+		}
+		sort.Slice(keysForMapSfixed32Sfixed32, func(i, j int) bool {
+			return keysForMapSfixed32Sfixed32[i] < keysForMapSfixed32Sfixed32[j]
+		})
+		for iNdEx := len(keysForMapSfixed32Sfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed32Sfixed32[int32(keysForMapSfixed32Sfixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapSfixed32Sfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.MapFixed64Fixed64) > 0 {
+		keysForMapFixed64Fixed64 := make([]uint64, 0, len(m.MapFixed64Fixed64))
+		for k := range m.MapFixed64Fixed64 {
+			keysForMapFixed64Fixed64 = append(keysForMapFixed64Fixed64, uint64(k))
+		}
+		sort.Slice(keysForMapFixed64Fixed64, func(i, j int) bool {
+			return keysForMapFixed64Fixed64[i] < keysForMapFixed64Fixed64[j]
+		})
+		for iNdEx := len(keysForMapFixed64Fixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed64Fixed64[uint64(keysForMapFixed64Fixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapFixed64Fixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
+	if len(m.MapFixed32Fixed32) > 0 {
+		keysForMapFixed32Fixed32 := make([]uint32, 0, len(m.MapFixed32Fixed32))
+		for k := range m.MapFixed32Fixed32 {
+			keysForMapFixed32Fixed32 = append(keysForMapFixed32Fixed32, uint32(k))
+		}
+		sort.Slice(keysForMapFixed32Fixed32, func(i, j int) bool {
+			return keysForMapFixed32Fixed32[i] < keysForMapFixed32Fixed32[j]
+		})
+		for iNdEx := len(keysForMapFixed32Fixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed32Fixed32[uint32(keysForMapFixed32Fixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapFixed32Fixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xf2
+		}
+	}
+	if len(m.MapSint64Sint64) > 0 {
+		keysForMapSint64Sint64 := make([]int64, 0, len(m.MapSint64Sint64))
+		for k := range m.MapSint64Sint64 {
+			keysForMapSint64Sint64 = append(keysForMapSint64Sint64, int64(k))
+		}
+		sort.Slice(keysForMapSint64Sint64, func(i, j int) bool {
+			return keysForMapSint64Sint64[i] < keysForMapSint64Sint64[j]
+		})
+		for iNdEx := len(keysForMapSint64Sint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint64Sint64[int64(keysForMapSint64Sint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(v)<<1)^uint64((v>>63))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(keysForMapSint64Sint64[iNdEx])<<1)^uint64((keysForMapSint64Sint64[iNdEx]>>63))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.MapSint32Sint32) > 0 {
+		keysForMapSint32Sint32 := make([]int32, 0, len(m.MapSint32Sint32))
+		for k := range m.MapSint32Sint32 {
+			keysForMapSint32Sint32 = append(keysForMapSint32Sint32, int32(k))
+		}
+		sort.Slice(keysForMapSint32Sint32, func(i, j int) bool {
+			return keysForMapSint32Sint32[i] < keysForMapSint32Sint32[j]
+		})
+		for iNdEx := len(keysForMapSint32Sint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint32Sint32[int32(keysForMapSint32Sint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(v)<<1)^uint32((v>>31))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(keysForMapSint32Sint32[iNdEx])<<1)^uint32((keysForMapSint32Sint32[iNdEx]>>31))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.MapUint64Uint64) > 0 {
+		keysForMapUint64Uint64 := make([]uint64, 0, len(m.MapUint64Uint64))
+		for k := range m.MapUint64Uint64 {
+			keysForMapUint64Uint64 = append(keysForMapUint64Uint64, uint64(k))
+		}
+		sort.Slice(keysForMapUint64Uint64, func(i, j int) bool {
+			return keysForMapUint64Uint64[i] < keysForMapUint64Uint64[j]
+		})
+		for iNdEx := len(keysForMapUint64Uint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint64Uint64[uint64(keysForMapUint64Uint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint64Uint64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.MapUint32Uint32) > 0 {
+		keysForMapUint32Uint32 := make([]uint32, 0, len(m.MapUint32Uint32))
+		for k := range m.MapUint32Uint32 {
+			keysForMapUint32Uint32 = append(keysForMapUint32Uint32, uint32(k))
+		}
+		sort.Slice(keysForMapUint32Uint32, func(i, j int) bool {
+			return keysForMapUint32Uint32[i] < keysForMapUint32Uint32[j]
+		})
+		for iNdEx := len(keysForMapUint32Uint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint32Uint32[uint32(keysForMapUint32Uint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint32Uint32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapInt64Int64) > 0 {
+		keysForMapInt64Int64 := make([]int64, 0, len(m.MapInt64Int64))
+		for k := range m.MapInt64Int64 {
+			keysForMapInt64Int64 = append(keysForMapInt64Int64, int64(k))
+		}
+		sort.Slice(keysForMapInt64Int64, func(i, j int) bool {
+			return keysForMapInt64Int64[i] < keysForMapInt64Int64[j]
+		})
+		for iNdEx := len(keysForMapInt64Int64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt64Int64[int64(keysForMapInt64Int64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt64Int64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapInt32Int32) > 0 {
+		keysForMapInt32Int32 := make([]int32, 0, len(m.MapInt32Int32))
+		for k := range m.MapInt32Int32 {
+			keysForMapInt32Int32 = append(keysForMapInt32Int32, int32(k))
+		}
+		sort.Slice(keysForMapInt32Int32, func(i, j int) bool {
+			return keysForMapInt32Int32[i] < keysForMapInt32Int32[j]
+		})
+		for iNdEx := len(keysForMapInt32Int32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Int32[int32(keysForMapInt32Int32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Int32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedCord) > 0 {
+		for iNdEx := len(m.RepeatedCord) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedCord[iNdEx])
+			copy(dAtA[i:], m.RepeatedCord[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedCord[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedStringPiece) > 0 {
+		for iNdEx := len(m.RepeatedStringPiece) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedStringPiece[iNdEx])
+			copy(dAtA[i:], m.RepeatedStringPiece[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedStringPiece[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedForeignEnum) > 0 {
+		for iNdEx := len(m.RepeatedForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedForeignEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xa0
+		}
+	}
+	if len(m.RepeatedNestedEnum) > 0 {
+		for iNdEx := len(m.RepeatedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if len(m.RepeatedForeignMessage) > 0 {
+		for iNdEx := len(m.RepeatedForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedForeignMessage[iNdEx].MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.RepeatedNestedMessage) > 0 {
+		for iNdEx := len(m.RepeatedNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedNestedMessage[iNdEx].MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.RepeatedBytes) > 0 {
+		for iNdEx := len(m.RepeatedBytes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedBytes[iNdEx])
+			copy(dAtA[i:], m.RepeatedBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBytes[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedString) > 0 {
+		for iNdEx := len(m.RepeatedString) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedString[iNdEx])
+			copy(dAtA[i:], m.RepeatedString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedString[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedBool) > 0 {
+		for iNdEx := len(m.RepeatedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.RepeatedDouble) > 0 {
+		for iNdEx := len(m.RepeatedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f23 := math.Float64bits(float64(m.RepeatedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f23))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xd1
+		}
+	}
+	if len(m.RepeatedFloat) > 0 {
+		for iNdEx := len(m.RepeatedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f24 := math.Float32bits(float32(m.RepeatedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f24))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xcd
+		}
+	}
+	if len(m.RepeatedSfixed64) > 0 {
+		for iNdEx := len(m.RepeatedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xc1
+		}
+	}
+	if len(m.RepeatedSfixed32) > 0 {
+		for iNdEx := len(m.RepeatedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xbd
+		}
+	}
+	if len(m.RepeatedFixed64) > 0 {
+		for iNdEx := len(m.RepeatedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xb1
+		}
+	}
+	if len(m.RepeatedFixed32) > 0 {
+		for iNdEx := len(m.RepeatedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xad
+		}
+	}
+	if len(m.RepeatedSint64) > 0 {
+		for iNdEx := len(m.RepeatedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x25 := (uint64(m.RepeatedSint64[iNdEx]) << 1) ^ uint64((m.RepeatedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x25))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xa0
+		}
+	}
+	if len(m.RepeatedSint32) > 0 {
+		for iNdEx := len(m.RepeatedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x26 := (uint32(m.RepeatedSint32[iNdEx]) << 1) ^ uint32((m.RepeatedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x26))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if len(m.RepeatedUint64) > 0 {
+		for iNdEx := len(m.RepeatedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x90
+		}
+	}
+	if len(m.RepeatedUint32) > 0 {
+		for iNdEx := len(m.RepeatedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x88
+		}
+	}
+	if len(m.RepeatedInt64) > 0 {
+		for iNdEx := len(m.RepeatedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x80
+		}
+	}
+	if len(m.RepeatedInt32) > 0 {
+		for iNdEx := len(m.RepeatedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xf8
+		}
+	}
+	if m.RecursiveMessage != nil {
+		size, err := m.RecursiveMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalCord != nil {
+		i -= len(*m.OptionalCord)
+		copy(dAtA[i:], *m.OptionalCord)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalCord)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	if m.OptionalStringPiece != nil {
+		i -= len(*m.OptionalStringPiece)
+		copy(dAtA[i:], *m.OptionalStringPiece)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalStringPiece)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
+	if m.OptionalForeignEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalForeignEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.OptionalNestedEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalNestedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.OptionalForeignMessage != nil {
+		size, err := m.OptionalForeignMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
+	if m.OptionalNestedMessage != nil {
+		size, err := m.OptionalNestedMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.OptionalBytes != nil {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalSint64)<<1)^uint64((*m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalSint32)<<1)^uint32((*m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto2_OneofUint32) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofUint32) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint32))
+	i--
+	dAtA[i] = 0x6
+	i--
+	dAtA[i] = 0xf8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofNestedMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofNestedMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.OneofNestedMessage != nil {
+		size, err := m.OneofNestedMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7
+		i--
+		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofString) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofString) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofString)
+	copy(dAtA[i:], m.OneofString)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofString)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x8a
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofBytes) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofBytes) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofBytes)
+	copy(dAtA[i:], m.OneofBytes)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofBytes)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x92
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofBool) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofBool) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.OneofBool {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x98
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofUint64) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofUint64) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint64))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xa0
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofFloat) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofFloat) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 4
+	binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OneofFloat))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xad
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofDouble) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofDouble) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OneofDouble))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb1
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto2_OneofEnum) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto2_OneofEnum) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofEnum))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb8
+	return len(dAtA) - i, nil
+}
+func (m *ForeignMessageProto2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ForeignMessageProto2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ForeignMessageProto2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.C))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnknownToTestAllTypes_OptionalGroup) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnknownToTestAllTypes) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnknownToTestAllTypes) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnknownToTestAllTypes) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedInt32) > 0 {
+		for iNdEx := len(m.RepeatedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x3f
+			i--
+			dAtA[i] = 0x98
+		}
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.Optionalgroup != nil {
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xe4
+		size, err := m.Optionalgroup.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xe3
+	}
+	if m.NestedMessage != nil {
+		size, err := m.NestedMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xc8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NullHypothesisProto2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NullHypothesisProto2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *NullHypothesisProto2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumOnlyProto2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumOnlyProto2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *EnumOnlyProto2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneStringProto2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneStringProto2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneStringProto2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}

--- a/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
+++ b/conformance/internal/conformance/test_messages_proto3_vtproto.pb.go
@@ -24,6 +24,7 @@ import (
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	io "io"
 	math "math"
+	sort "sort"
 	unsafe "unsafe"
 )
 
@@ -4329,6 +4330,4605 @@ func (m *EnumOnlyProto3) MarshalToVT(dAtA []byte) (int, error) {
 }
 
 func (m *EnumOnlyProto3) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Corecursive != nil {
+		size, err := m.Corecursive.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.OneofField.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m.FieldName18__ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName18__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.FieldName17__ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName17__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Field__Name16 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field__Name16))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Field_Name15 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name15))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.X_FieldName14 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.X_FieldName14))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.XFieldName13 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.XFieldName13))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.FIELDName12 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FIELDName12))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.FIELD_NAME11 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FIELD_NAME11))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.Field_Name10 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name10))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd0
+	}
+	if m.Field_Name9 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name9))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc8
+	}
+	if m.FieldName8 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName8))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc0
+	}
+	if m.FieldName7 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName7))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.Field_0Name6 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_0Name6))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.Field0Name5 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field0Name5))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.Field_Name4_ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name4_))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.XFieldName3 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.XFieldName3))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.FieldName2 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName2))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.Fieldname1 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Fieldname1))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x88
+	}
+	if len(m.RepeatedStruct) > 0 {
+		for iNdEx := len(m.RepeatedStruct) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.Struct)(m.RepeatedStruct[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x14
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.RepeatedListValue) > 0 {
+		for iNdEx := len(m.RepeatedListValue) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.ListValue)(m.RepeatedListValue[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedValue) > 0 {
+		for iNdEx := len(m.RepeatedValue) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.Value)(m.RepeatedValue[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedAny) > 0 {
+		for iNdEx := len(m.RepeatedAny) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*anypb1.Any)(m.RepeatedAny[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.RepeatedFieldmask) > 0 {
+		for iNdEx := len(m.RepeatedFieldmask) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*fieldmaskpb1.FieldMask)(m.RepeatedFieldmask[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.RepeatedTimestamp) > 0 {
+		for iNdEx := len(m.RepeatedTimestamp) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*timestamppb1.Timestamp)(m.RepeatedTimestamp[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedDuration) > 0 {
+		for iNdEx := len(m.RepeatedDuration) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*durationpb1.Duration)(m.RepeatedDuration[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if m.OptionalNullValue != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalNullValue))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.OptionalValue != nil {
+		size, err := (*structpb1.Value)(m.OptionalValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.OptionalAny != nil {
+		size, err := (*anypb1.Any)(m.OptionalAny).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.OptionalStruct != nil {
+		size, err := (*structpb1.Struct)(m.OptionalStruct).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.OptionalFieldMask != nil {
+		size, err := (*fieldmaskpb1.FieldMask)(m.OptionalFieldMask).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.OptionalTimestamp != nil {
+		size, err := (*timestamppb1.Timestamp)(m.OptionalTimestamp).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.OptionalDuration != nil {
+		size, err := (*durationpb1.Duration)(m.OptionalDuration).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.RepeatedBytesWrapper) > 0 {
+		for iNdEx := len(m.RepeatedBytesWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.BytesValue)(m.RepeatedBytesWrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.RepeatedStringWrapper) > 0 {
+		for iNdEx := len(m.RepeatedStringWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.StringValue)(m.RepeatedStringWrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.RepeatedDoubleWrapper) > 0 {
+		for iNdEx := len(m.RepeatedDoubleWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.DoubleValue)(m.RepeatedDoubleWrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.RepeatedFloatWrapper) > 0 {
+		for iNdEx := len(m.RepeatedFloatWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.FloatValue)(m.RepeatedFloatWrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedUint64Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedUint64Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.UInt64Value)(m.RepeatedUint64Wrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedUint32Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedUint32Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.UInt32Value)(m.RepeatedUint32Wrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedInt64Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedInt64Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.Int64Value)(m.RepeatedInt64Wrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.RepeatedInt32Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedInt32Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.Int32Value)(m.RepeatedInt32Wrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.RepeatedBoolWrapper) > 0 {
+		for iNdEx := len(m.RepeatedBoolWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.BoolValue)(m.RepeatedBoolWrapper[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if m.OptionalBytesWrapper != nil {
+		size, err := (*wrapperspb1.BytesValue)(m.OptionalBytesWrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xd
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.OptionalStringWrapper != nil {
+		size, err := (*wrapperspb1.StringValue)(m.OptionalStringWrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xd
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.OptionalDoubleWrapper != nil {
+		size, err := (*wrapperspb1.DoubleValue)(m.OptionalDoubleWrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.OptionalFloatWrapper != nil {
+		size, err := (*wrapperspb1.FloatValue)(m.OptionalFloatWrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.OptionalUint64Wrapper != nil {
+		size, err := (*wrapperspb1.UInt64Value)(m.OptionalUint64Wrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xea
+	}
+	if m.OptionalUint32Wrapper != nil {
+		size, err := (*wrapperspb1.UInt32Value)(m.OptionalUint32Wrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xe2
+	}
+	if m.OptionalInt64Wrapper != nil {
+		size, err := (*wrapperspb1.Int64Value)(m.OptionalInt64Wrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalInt32Wrapper != nil {
+		size, err := (*wrapperspb1.Int32Value)(m.OptionalInt32Wrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.OptionalBoolWrapper != nil {
+		size, err := (*wrapperspb1.BoolValue)(m.OptionalBoolWrapper).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xca
+	}
+	if len(m.UnpackedNestedEnum) > 0 {
+		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xb0
+		}
+	}
+	if len(m.UnpackedBool) > 0 {
+		for iNdEx := len(m.UnpackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.UnpackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa8
+		}
+	}
+	if len(m.UnpackedDouble) > 0 {
+		for iNdEx := len(m.UnpackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.UnpackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa1
+		}
+	}
+	if len(m.UnpackedFloat) > 0 {
+		for iNdEx := len(m.UnpackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.UnpackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x9d
+		}
+	}
+	if len(m.UnpackedSfixed64) > 0 {
+		for iNdEx := len(m.UnpackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x91
+		}
+	}
+	if len(m.UnpackedSfixed32) > 0 {
+		for iNdEx := len(m.UnpackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x8d
+		}
+	}
+	if len(m.UnpackedFixed64) > 0 {
+		for iNdEx := len(m.UnpackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x81
+		}
+	}
+	if len(m.UnpackedFixed32) > 0 {
+		for iNdEx := len(m.UnpackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xfd
+		}
+	}
+	if len(m.UnpackedSint64) > 0 {
+		for iNdEx := len(m.UnpackedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x3 := (uint64(m.UnpackedSint64[iNdEx]) << 1) ^ uint64((m.UnpackedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x3))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xf0
+		}
+	}
+	if len(m.UnpackedSint32) > 0 {
+		for iNdEx := len(m.UnpackedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.UnpackedSint32[iNdEx]) << 1) ^ uint32((m.UnpackedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe8
+		}
+	}
+	if len(m.UnpackedUint64) > 0 {
+		for iNdEx := len(m.UnpackedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe0
+		}
+	}
+	if len(m.UnpackedUint32) > 0 {
+		for iNdEx := len(m.UnpackedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.UnpackedInt64) > 0 {
+		for iNdEx := len(m.UnpackedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd0
+		}
+	}
+	if len(m.UnpackedInt32) > 0 {
+		for iNdEx := len(m.UnpackedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xc8
+		}
+	}
+	if len(m.PackedNestedEnum) > 0 {
+		var pksize6 int
+		for _, num := range m.PackedNestedEnum {
+			pksize6 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize6
+		j5 := i
+		for _, num1 := range m.PackedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j5] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j5++
+			}
+			dAtA[j5] = uint8(num)
+			j5++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize6))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.PackedBool) > 0 {
+		for iNdEx := len(m.PackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedBool)))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.PackedDouble) > 0 {
+		for iNdEx := len(m.PackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f7 := math.Float64bits(float64(m.PackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f7))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedDouble)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.PackedFloat) > 0 {
+		for iNdEx := len(m.PackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f8 := math.Float32bits(float32(m.PackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f8))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFloat)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.PackedSfixed64) > 0 {
+		for iNdEx := len(m.PackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.PackedSfixed32) > 0 {
+		for iNdEx := len(m.PackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.PackedFixed64) > 0 {
+		for iNdEx := len(m.PackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.PackedFixed32) > 0 {
+		for iNdEx := len(m.PackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.PackedSint64) > 0 {
+		var pksize10 int
+		for _, num := range m.PackedSint64 {
+			pksize10 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize10
+		j9 := i
+		for _, num := range m.PackedSint64 {
+			x11 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x11 >= 1<<7 {
+				dAtA[j9] = uint8(uint64(x11)&0x7f | 0x80)
+				j9++
+				x11 >>= 7
+			}
+			dAtA[j9] = uint8(x11)
+			j9++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize10))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.PackedSint32) > 0 {
+		var pksize13 int
+		for _, num := range m.PackedSint32 {
+			pksize13 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize13
+		j12 := i
+		for _, num := range m.PackedSint32 {
+			x14 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x14 >= 1<<7 {
+				dAtA[j12] = uint8(uint64(x14)&0x7f | 0x80)
+				j12++
+				x14 >>= 7
+			}
+			dAtA[j12] = uint8(x14)
+			j12++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize13))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xfa
+	}
+	if len(m.PackedUint64) > 0 {
+		var pksize16 int
+		for _, num := range m.PackedUint64 {
+			pksize16 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize16
+		j15 := i
+		for _, num := range m.PackedUint64 {
+			for num >= 1<<7 {
+				dAtA[j15] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j15++
+			}
+			dAtA[j15] = uint8(num)
+			j15++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize16))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xf2
+	}
+	if len(m.PackedUint32) > 0 {
+		var pksize18 int
+		for _, num := range m.PackedUint32 {
+			pksize18 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize18
+		j17 := i
+		for _, num := range m.PackedUint32 {
+			for num >= 1<<7 {
+				dAtA[j17] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j17++
+			}
+			dAtA[j17] = uint8(num)
+			j17++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize18))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.PackedInt64) > 0 {
+		var pksize20 int
+		for _, num := range m.PackedInt64 {
+			pksize20 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize20
+		j19 := i
+		for _, num1 := range m.PackedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j19] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j19++
+			}
+			dAtA[j19] = uint8(num)
+			j19++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize20))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xe2
+	}
+	if len(m.PackedInt32) > 0 {
+		var pksize22 int
+		for _, num := range m.PackedInt32 {
+			pksize22 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize22
+		j21 := i
+		for _, num1 := range m.PackedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j21] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j21++
+			}
+			dAtA[j21] = uint8(num)
+			j21++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize22))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.MapStringForeignEnum) > 0 {
+		keysForMapStringForeignEnum := make([]string, 0, len(m.MapStringForeignEnum))
+		for k := range m.MapStringForeignEnum {
+			keysForMapStringForeignEnum = append(keysForMapStringForeignEnum, string(k))
+		}
+		sort.Slice(keysForMapStringForeignEnum, func(i, j int) bool {
+			return keysForMapStringForeignEnum[i] < keysForMapStringForeignEnum[j]
+		})
+		for iNdEx := len(keysForMapStringForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignEnum[string(keysForMapStringForeignEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringForeignEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapStringNestedEnum) > 0 {
+		keysForMapStringNestedEnum := make([]string, 0, len(m.MapStringNestedEnum))
+		for k := range m.MapStringNestedEnum {
+			keysForMapStringNestedEnum = append(keysForMapStringNestedEnum, string(k))
+		}
+		sort.Slice(keysForMapStringNestedEnum, func(i, j int) bool {
+			return keysForMapStringNestedEnum[i] < keysForMapStringNestedEnum[j]
+		})
+		for iNdEx := len(keysForMapStringNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedEnum[string(keysForMapStringNestedEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringNestedEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapStringForeignMessage) > 0 {
+		keysForMapStringForeignMessage := make([]string, 0, len(m.MapStringForeignMessage))
+		for k := range m.MapStringForeignMessage {
+			keysForMapStringForeignMessage = append(keysForMapStringForeignMessage, string(k))
+		}
+		sort.Slice(keysForMapStringForeignMessage, func(i, j int) bool {
+			return keysForMapStringForeignMessage[i] < keysForMapStringForeignMessage[j]
+		})
+		for iNdEx := len(keysForMapStringForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignMessage[string(keysForMapStringForeignMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringForeignMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.MapStringNestedMessage) > 0 {
+		keysForMapStringNestedMessage := make([]string, 0, len(m.MapStringNestedMessage))
+		for k := range m.MapStringNestedMessage {
+			keysForMapStringNestedMessage = append(keysForMapStringNestedMessage, string(k))
+		}
+		sort.Slice(keysForMapStringNestedMessage, func(i, j int) bool {
+			return keysForMapStringNestedMessage[i] < keysForMapStringNestedMessage[j]
+		})
+		for iNdEx := len(keysForMapStringNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedMessage[string(keysForMapStringNestedMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringNestedMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.MapStringBytes) > 0 {
+		keysForMapStringBytes := make([]string, 0, len(m.MapStringBytes))
+		for k := range m.MapStringBytes {
+			keysForMapStringBytes = append(keysForMapStringBytes, string(k))
+		}
+		sort.Slice(keysForMapStringBytes, func(i, j int) bool {
+			return keysForMapStringBytes[i] < keysForMapStringBytes[j]
+		})
+		for iNdEx := len(keysForMapStringBytes) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringBytes[string(keysForMapStringBytes[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringBytes[iNdEx])
+			copy(dAtA[i:], keysForMapStringBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringBytes[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.MapStringString) > 0 {
+		keysForMapStringString := make([]string, 0, len(m.MapStringString))
+		for k := range m.MapStringString {
+			keysForMapStringString = append(keysForMapStringString, string(k))
+		}
+		sort.Slice(keysForMapStringString, func(i, j int) bool {
+			return keysForMapStringString[i] < keysForMapStringString[j]
+		})
+		for iNdEx := len(keysForMapStringString) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringString[string(keysForMapStringString[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringString[iNdEx])
+			copy(dAtA[i:], keysForMapStringString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringString[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.MapBoolBool) > 0 {
+		for k := range m.MapBoolBool {
+			v := m.MapBoolBool[bool(k)]
+			baseI := i
+			i--
+			if v {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x10
+			i--
+			if k {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.MapInt32Double) > 0 {
+		keysForMapInt32Double := make([]int32, 0, len(m.MapInt32Double))
+		for k := range m.MapInt32Double {
+			keysForMapInt32Double = append(keysForMapInt32Double, int32(k))
+		}
+		sort.Slice(keysForMapInt32Double, func(i, j int) bool {
+			return keysForMapInt32Double[i] < keysForMapInt32Double[j]
+		})
+		for iNdEx := len(keysForMapInt32Double) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Double[int32(keysForMapInt32Double[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(v))))
+			i--
+			dAtA[i] = 0x11
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Double[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if len(m.MapInt32Float) > 0 {
+		keysForMapInt32Float := make([]int32, 0, len(m.MapInt32Float))
+		for k := range m.MapInt32Float {
+			keysForMapInt32Float = append(keysForMapInt32Float, int32(k))
+		}
+		sort.Slice(keysForMapInt32Float, func(i, j int) bool {
+			return keysForMapInt32Float[i] < keysForMapInt32Float[j]
+		})
+		for iNdEx := len(keysForMapInt32Float) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Float[int32(keysForMapInt32Float[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(v))))
+			i--
+			dAtA[i] = 0x15
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Float[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x92
+		}
+	}
+	if len(m.MapSfixed64Sfixed64) > 0 {
+		keysForMapSfixed64Sfixed64 := make([]int64, 0, len(m.MapSfixed64Sfixed64))
+		for k := range m.MapSfixed64Sfixed64 {
+			keysForMapSfixed64Sfixed64 = append(keysForMapSfixed64Sfixed64, int64(k))
+		}
+		sort.Slice(keysForMapSfixed64Sfixed64, func(i, j int) bool {
+			return keysForMapSfixed64Sfixed64[i] < keysForMapSfixed64Sfixed64[j]
+		})
+		for iNdEx := len(keysForMapSfixed64Sfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed64Sfixed64[int64(keysForMapSfixed64Sfixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapSfixed64Sfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.MapSfixed32Sfixed32) > 0 {
+		keysForMapSfixed32Sfixed32 := make([]int32, 0, len(m.MapSfixed32Sfixed32))
+		for k := range m.MapSfixed32Sfixed32 {
+			keysForMapSfixed32Sfixed32 = append(keysForMapSfixed32Sfixed32, int32(k))
+		}
+		sort.Slice(keysForMapSfixed32Sfixed32, func(i, j int) bool {
+			return keysForMapSfixed32Sfixed32[i] < keysForMapSfixed32Sfixed32[j]
+		})
+		for iNdEx := len(keysForMapSfixed32Sfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed32Sfixed32[int32(keysForMapSfixed32Sfixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapSfixed32Sfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.MapFixed64Fixed64) > 0 {
+		keysForMapFixed64Fixed64 := make([]uint64, 0, len(m.MapFixed64Fixed64))
+		for k := range m.MapFixed64Fixed64 {
+			keysForMapFixed64Fixed64 = append(keysForMapFixed64Fixed64, uint64(k))
+		}
+		sort.Slice(keysForMapFixed64Fixed64, func(i, j int) bool {
+			return keysForMapFixed64Fixed64[i] < keysForMapFixed64Fixed64[j]
+		})
+		for iNdEx := len(keysForMapFixed64Fixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed64Fixed64[uint64(keysForMapFixed64Fixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapFixed64Fixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
+	if len(m.MapFixed32Fixed32) > 0 {
+		keysForMapFixed32Fixed32 := make([]uint32, 0, len(m.MapFixed32Fixed32))
+		for k := range m.MapFixed32Fixed32 {
+			keysForMapFixed32Fixed32 = append(keysForMapFixed32Fixed32, uint32(k))
+		}
+		sort.Slice(keysForMapFixed32Fixed32, func(i, j int) bool {
+			return keysForMapFixed32Fixed32[i] < keysForMapFixed32Fixed32[j]
+		})
+		for iNdEx := len(keysForMapFixed32Fixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed32Fixed32[uint32(keysForMapFixed32Fixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapFixed32Fixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xf2
+		}
+	}
+	if len(m.MapSint64Sint64) > 0 {
+		keysForMapSint64Sint64 := make([]int64, 0, len(m.MapSint64Sint64))
+		for k := range m.MapSint64Sint64 {
+			keysForMapSint64Sint64 = append(keysForMapSint64Sint64, int64(k))
+		}
+		sort.Slice(keysForMapSint64Sint64, func(i, j int) bool {
+			return keysForMapSint64Sint64[i] < keysForMapSint64Sint64[j]
+		})
+		for iNdEx := len(keysForMapSint64Sint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint64Sint64[int64(keysForMapSint64Sint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(v)<<1)^uint64((v>>63))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(keysForMapSint64Sint64[iNdEx])<<1)^uint64((keysForMapSint64Sint64[iNdEx]>>63))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.MapSint32Sint32) > 0 {
+		keysForMapSint32Sint32 := make([]int32, 0, len(m.MapSint32Sint32))
+		for k := range m.MapSint32Sint32 {
+			keysForMapSint32Sint32 = append(keysForMapSint32Sint32, int32(k))
+		}
+		sort.Slice(keysForMapSint32Sint32, func(i, j int) bool {
+			return keysForMapSint32Sint32[i] < keysForMapSint32Sint32[j]
+		})
+		for iNdEx := len(keysForMapSint32Sint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint32Sint32[int32(keysForMapSint32Sint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(v)<<1)^uint32((v>>31))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(keysForMapSint32Sint32[iNdEx])<<1)^uint32((keysForMapSint32Sint32[iNdEx]>>31))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.MapUint64Uint64) > 0 {
+		keysForMapUint64Uint64 := make([]uint64, 0, len(m.MapUint64Uint64))
+		for k := range m.MapUint64Uint64 {
+			keysForMapUint64Uint64 = append(keysForMapUint64Uint64, uint64(k))
+		}
+		sort.Slice(keysForMapUint64Uint64, func(i, j int) bool {
+			return keysForMapUint64Uint64[i] < keysForMapUint64Uint64[j]
+		})
+		for iNdEx := len(keysForMapUint64Uint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint64Uint64[uint64(keysForMapUint64Uint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint64Uint64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.MapUint32Uint32) > 0 {
+		keysForMapUint32Uint32 := make([]uint32, 0, len(m.MapUint32Uint32))
+		for k := range m.MapUint32Uint32 {
+			keysForMapUint32Uint32 = append(keysForMapUint32Uint32, uint32(k))
+		}
+		sort.Slice(keysForMapUint32Uint32, func(i, j int) bool {
+			return keysForMapUint32Uint32[i] < keysForMapUint32Uint32[j]
+		})
+		for iNdEx := len(keysForMapUint32Uint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint32Uint32[uint32(keysForMapUint32Uint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint32Uint32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapInt64Int64) > 0 {
+		keysForMapInt64Int64 := make([]int64, 0, len(m.MapInt64Int64))
+		for k := range m.MapInt64Int64 {
+			keysForMapInt64Int64 = append(keysForMapInt64Int64, int64(k))
+		}
+		sort.Slice(keysForMapInt64Int64, func(i, j int) bool {
+			return keysForMapInt64Int64[i] < keysForMapInt64Int64[j]
+		})
+		for iNdEx := len(keysForMapInt64Int64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt64Int64[int64(keysForMapInt64Int64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt64Int64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapInt32Int32) > 0 {
+		keysForMapInt32Int32 := make([]int32, 0, len(m.MapInt32Int32))
+		for k := range m.MapInt32Int32 {
+			keysForMapInt32Int32 = append(keysForMapInt32Int32, int32(k))
+		}
+		sort.Slice(keysForMapInt32Int32, func(i, j int) bool {
+			return keysForMapInt32Int32[i] < keysForMapInt32Int32[j]
+		})
+		for iNdEx := len(keysForMapInt32Int32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Int32[int32(keysForMapInt32Int32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Int32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedCord) > 0 {
+		for iNdEx := len(m.RepeatedCord) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedCord[iNdEx])
+			copy(dAtA[i:], m.RepeatedCord[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedCord[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedStringPiece) > 0 {
+		for iNdEx := len(m.RepeatedStringPiece) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedStringPiece[iNdEx])
+			copy(dAtA[i:], m.RepeatedStringPiece[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedStringPiece[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedForeignEnum) > 0 {
+		var pksize24 int
+		for _, num := range m.RepeatedForeignEnum {
+			pksize24 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize24
+		j23 := i
+		for _, num1 := range m.RepeatedForeignEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j23] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j23++
+			}
+			dAtA[j23] = uint8(num)
+			j23++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize24))
+		i--
+		dAtA[i] = 0x3
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.RepeatedNestedEnum) > 0 {
+		var pksize26 int
+		for _, num := range m.RepeatedNestedEnum {
+			pksize26 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize26
+		j25 := i
+		for _, num1 := range m.RepeatedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j25] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j25++
+			}
+			dAtA[j25] = uint8(num)
+			j25++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize26))
+		i--
+		dAtA[i] = 0x3
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.RepeatedForeignMessage) > 0 {
+		for iNdEx := len(m.RepeatedForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedForeignMessage[iNdEx].MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.RepeatedNestedMessage) > 0 {
+		for iNdEx := len(m.RepeatedNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedNestedMessage[iNdEx].MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.RepeatedBytes) > 0 {
+		for iNdEx := len(m.RepeatedBytes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedBytes[iNdEx])
+			copy(dAtA[i:], m.RepeatedBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBytes[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedString) > 0 {
+		for iNdEx := len(m.RepeatedString) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedString[iNdEx])
+			copy(dAtA[i:], m.RepeatedString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedString[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedBool) > 0 {
+		for iNdEx := len(m.RepeatedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBool)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.RepeatedDouble) > 0 {
+		for iNdEx := len(m.RepeatedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f27 := math.Float64bits(float64(m.RepeatedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f27))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedDouble)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xd2
+	}
+	if len(m.RepeatedFloat) > 0 {
+		for iNdEx := len(m.RepeatedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f28 := math.Float32bits(float32(m.RepeatedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f28))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFloat)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xca
+	}
+	if len(m.RepeatedSfixed64) > 0 {
+		for iNdEx := len(m.RepeatedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedSfixed64)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.RepeatedSfixed32) > 0 {
+		for iNdEx := len(m.RepeatedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedSfixed32)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.RepeatedFixed64) > 0 {
+		for iNdEx := len(m.RepeatedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFixed64)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.RepeatedFixed32) > 0 {
+		for iNdEx := len(m.RepeatedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFixed32)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.RepeatedSint64) > 0 {
+		var pksize30 int
+		for _, num := range m.RepeatedSint64 {
+			pksize30 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize30
+		j29 := i
+		for _, num := range m.RepeatedSint64 {
+			x31 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x31 >= 1<<7 {
+				dAtA[j29] = uint8(uint64(x31)&0x7f | 0x80)
+				j29++
+				x31 >>= 7
+			}
+			dAtA[j29] = uint8(x31)
+			j29++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize30))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.RepeatedSint32) > 0 {
+		var pksize33 int
+		for _, num := range m.RepeatedSint32 {
+			pksize33 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize33
+		j32 := i
+		for _, num := range m.RepeatedSint32 {
+			x34 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x34 >= 1<<7 {
+				dAtA[j32] = uint8(uint64(x34)&0x7f | 0x80)
+				j32++
+				x34 >>= 7
+			}
+			dAtA[j32] = uint8(x34)
+			j32++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize33))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.RepeatedUint64) > 0 {
+		var pksize36 int
+		for _, num := range m.RepeatedUint64 {
+			pksize36 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize36
+		j35 := i
+		for _, num := range m.RepeatedUint64 {
+			for num >= 1<<7 {
+				dAtA[j35] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j35++
+			}
+			dAtA[j35] = uint8(num)
+			j35++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize36))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.RepeatedUint32) > 0 {
+		var pksize38 int
+		for _, num := range m.RepeatedUint32 {
+			pksize38 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize38
+		j37 := i
+		for _, num := range m.RepeatedUint32 {
+			for num >= 1<<7 {
+				dAtA[j37] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j37++
+			}
+			dAtA[j37] = uint8(num)
+			j37++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize38))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.RepeatedInt64) > 0 {
+		var pksize40 int
+		for _, num := range m.RepeatedInt64 {
+			pksize40 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize40
+		j39 := i
+		for _, num1 := range m.RepeatedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j39] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j39++
+			}
+			dAtA[j39] = uint8(num)
+			j39++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize40))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.RepeatedInt32) > 0 {
+		var pksize42 int
+		for _, num := range m.RepeatedInt32 {
+			pksize42 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize42
+		j41 := i
+		for _, num1 := range m.RepeatedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j41] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j41++
+			}
+			dAtA[j41] = uint8(num)
+			j41++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize42))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.RecursiveMessage != nil {
+		size, err := m.RecursiveMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.OptionalCord) > 0 {
+		i -= len(m.OptionalCord)
+		copy(dAtA[i:], m.OptionalCord)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalCord)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	if len(m.OptionalStringPiece) > 0 {
+		i -= len(m.OptionalStringPiece)
+		copy(dAtA[i:], m.OptionalStringPiece)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalStringPiece)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
+	if m.OptionalAliasedEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalAliasedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.OptionalForeignEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalForeignEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.OptionalNestedEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalNestedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.OptionalForeignMessage != nil {
+		size, err := m.OptionalForeignMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
+	if m.OptionalNestedMessage != nil {
+		size, err := m.OptionalNestedMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.OptionalBytes) > 0 {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if len(m.OptionalString) > 0 {
+		i -= len(m.OptionalString)
+		copy(dAtA[i:], m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool {
+		i--
+		if m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(m.OptionalSint64)<<1)^uint64((m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(m.OptionalSint32)<<1)^uint32((m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3_OneofUint32) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofUint32) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint32))
+	i--
+	dAtA[i] = 0x6
+	i--
+	dAtA[i] = 0xf8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofNestedMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofNestedMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.OneofNestedMessage != nil {
+		size, err := m.OneofNestedMessage.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7
+		i--
+		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofString) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofString) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofString)
+	copy(dAtA[i:], m.OneofString)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofString)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x8a
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofBytes) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofBytes) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofBytes)
+	copy(dAtA[i:], m.OneofBytes)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofBytes)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x92
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofBool) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofBool) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.OneofBool {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x98
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofUint64) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofUint64) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint64))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xa0
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofFloat) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofFloat) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 4
+	binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OneofFloat))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xad
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofDouble) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofDouble) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OneofDouble))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb1
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofEnum) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofEnum) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofEnum))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofNullValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofNullValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofNullValue))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xc0
+	return len(dAtA) - i, nil
+}
+func (m *ForeignMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ForeignMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ForeignMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.C))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NullHypothesisProto3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NullHypothesisProto3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *NullHypothesisProto3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumOnlyProto3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumOnlyProto3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *EnumOnlyProto3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_NestedMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Corecursive != nil {
+		size, err := m.Corecursive.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestAllTypesProto3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.FieldName18__ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName18__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.FieldName17__ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName17__))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.Field__Name16 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field__Name16))
+		i--
+		dAtA[i] = 0x1a
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Field_Name15 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name15))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.X_FieldName14 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.X_FieldName14))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.XFieldName13 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.XFieldName13))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.FIELDName12 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FIELDName12))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.FIELD_NAME11 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FIELD_NAME11))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.Field_Name10 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name10))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xd0
+	}
+	if m.Field_Name9 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name9))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc8
+	}
+	if m.FieldName8 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName8))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xc0
+	}
+	if m.FieldName7 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName7))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.Field_0Name6 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_0Name6))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.Field0Name5 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field0Name5))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.Field_Name4_ != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field_Name4_))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.XFieldName3 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.XFieldName3))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.FieldName2 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName2))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.Fieldname1 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Fieldname1))
+		i--
+		dAtA[i] = 0x19
+		i--
+		dAtA[i] = 0x88
+	}
+	if len(m.RepeatedStruct) > 0 {
+		for iNdEx := len(m.RepeatedStruct) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.Struct)(m.RepeatedStruct[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x14
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.RepeatedListValue) > 0 {
+		for iNdEx := len(m.RepeatedListValue) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.ListValue)(m.RepeatedListValue[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedValue) > 0 {
+		for iNdEx := len(m.RepeatedValue) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*structpb1.Value)(m.RepeatedValue[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedAny) > 0 {
+		for iNdEx := len(m.RepeatedAny) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*anypb1.Any)(m.RepeatedAny[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.RepeatedFieldmask) > 0 {
+		for iNdEx := len(m.RepeatedFieldmask) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*fieldmaskpb1.FieldMask)(m.RepeatedFieldmask[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.RepeatedTimestamp) > 0 {
+		for iNdEx := len(m.RepeatedTimestamp) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*timestamppb1.Timestamp)(m.RepeatedTimestamp[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedDuration) > 0 {
+		for iNdEx := len(m.RepeatedDuration) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*durationpb1.Duration)(m.RepeatedDuration[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x13
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if m.OptionalNullValue != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalNullValue))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.OptionalValue != nil {
+		size, err := (*structpb1.Value)(m.OptionalValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.OptionalAny != nil {
+		size, err := (*anypb1.Any)(m.OptionalAny).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.OptionalStruct != nil {
+		size, err := (*structpb1.Struct)(m.OptionalStruct).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x13
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.OptionalFieldMask != nil {
+		size, err := (*fieldmaskpb1.FieldMask)(m.OptionalFieldMask).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.OptionalTimestamp != nil {
+		size, err := (*timestamppb1.Timestamp)(m.OptionalTimestamp).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.OptionalDuration != nil {
+		size, err := (*durationpb1.Duration)(m.OptionalDuration).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.RepeatedBytesWrapper) > 0 {
+		for iNdEx := len(m.RepeatedBytesWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.BytesValue)(m.RepeatedBytesWrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.RepeatedStringWrapper) > 0 {
+		for iNdEx := len(m.RepeatedStringWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.StringValue)(m.RepeatedStringWrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.RepeatedDoubleWrapper) > 0 {
+		for iNdEx := len(m.RepeatedDoubleWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.DoubleValue)(m.RepeatedDoubleWrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.RepeatedFloatWrapper) > 0 {
+		for iNdEx := len(m.RepeatedFloatWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.FloatValue)(m.RepeatedFloatWrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedUint64Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedUint64Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.UInt64Value)(m.RepeatedUint64Wrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedUint32Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedUint32Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.UInt32Value)(m.RepeatedUint32Wrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedInt64Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedInt64Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.Int64Value)(m.RepeatedInt64Wrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.RepeatedInt32Wrapper) > 0 {
+		for iNdEx := len(m.RepeatedInt32Wrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.Int32Value)(m.RepeatedInt32Wrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.RepeatedBoolWrapper) > 0 {
+		for iNdEx := len(m.RepeatedBoolWrapper) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*wrapperspb1.BoolValue)(m.RepeatedBoolWrapper[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xd
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if m.OptionalBytesWrapper != nil {
+		size, err := (*wrapperspb1.BytesValue)(m.OptionalBytesWrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xd
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.OptionalStringWrapper != nil {
+		size, err := (*wrapperspb1.StringValue)(m.OptionalStringWrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xd
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.OptionalDoubleWrapper != nil {
+		size, err := (*wrapperspb1.DoubleValue)(m.OptionalDoubleWrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.OptionalFloatWrapper != nil {
+		size, err := (*wrapperspb1.FloatValue)(m.OptionalFloatWrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xf2
+	}
+	if m.OptionalUint64Wrapper != nil {
+		size, err := (*wrapperspb1.UInt64Value)(m.OptionalUint64Wrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xea
+	}
+	if m.OptionalUint32Wrapper != nil {
+		size, err := (*wrapperspb1.UInt32Value)(m.OptionalUint32Wrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xe2
+	}
+	if m.OptionalInt64Wrapper != nil {
+		size, err := (*wrapperspb1.Int64Value)(m.OptionalInt64Wrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xda
+	}
+	if m.OptionalInt32Wrapper != nil {
+		size, err := (*wrapperspb1.Int32Value)(m.OptionalInt32Wrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.OptionalBoolWrapper != nil {
+		size, err := (*wrapperspb1.BoolValue)(m.OptionalBoolWrapper).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xc
+		i--
+		dAtA[i] = 0xca
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofNullValue); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofEnum); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofDouble); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofFloat); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofUint64); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofBool); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofBytes); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofString); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofNestedMessage); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.OneofField.(*TestAllTypesProto3_OneofUint32); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if len(m.UnpackedNestedEnum) > 0 {
+		for iNdEx := len(m.UnpackedNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedNestedEnum[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xb0
+		}
+	}
+	if len(m.UnpackedBool) > 0 {
+		for iNdEx := len(m.UnpackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.UnpackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa8
+		}
+	}
+	if len(m.UnpackedDouble) > 0 {
+		for iNdEx := len(m.UnpackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.UnpackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0xa1
+		}
+	}
+	if len(m.UnpackedFloat) > 0 {
+		for iNdEx := len(m.UnpackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.UnpackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x9d
+		}
+	}
+	if len(m.UnpackedSfixed64) > 0 {
+		for iNdEx := len(m.UnpackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedSfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x91
+		}
+	}
+	if len(m.UnpackedSfixed32) > 0 {
+		for iNdEx := len(m.UnpackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedSfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x8d
+		}
+	}
+	if len(m.UnpackedFixed64) > 0 {
+		for iNdEx := len(m.UnpackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.UnpackedFixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x6
+			i--
+			dAtA[i] = 0x81
+		}
+	}
+	if len(m.UnpackedFixed32) > 0 {
+		for iNdEx := len(m.UnpackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.UnpackedFixed32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xfd
+		}
+	}
+	if len(m.UnpackedSint64) > 0 {
+		for iNdEx := len(m.UnpackedSint64) - 1; iNdEx >= 0; iNdEx-- {
+			x3 := (uint64(m.UnpackedSint64[iNdEx]) << 1) ^ uint64((m.UnpackedSint64[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x3))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xf0
+		}
+	}
+	if len(m.UnpackedSint32) > 0 {
+		for iNdEx := len(m.UnpackedSint32) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.UnpackedSint32[iNdEx]) << 1) ^ uint32((m.UnpackedSint32[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe8
+		}
+	}
+	if len(m.UnpackedUint64) > 0 {
+		for iNdEx := len(m.UnpackedUint64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xe0
+		}
+	}
+	if len(m.UnpackedUint32) > 0 {
+		for iNdEx := len(m.UnpackedUint32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedUint32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd8
+		}
+	}
+	if len(m.UnpackedInt64) > 0 {
+		for iNdEx := len(m.UnpackedInt64) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt64[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xd0
+		}
+	}
+	if len(m.UnpackedInt32) > 0 {
+		for iNdEx := len(m.UnpackedInt32) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnpackedInt32[iNdEx]))
+			i--
+			dAtA[i] = 0x5
+			i--
+			dAtA[i] = 0xc8
+		}
+	}
+	if len(m.PackedNestedEnum) > 0 {
+		var pksize6 int
+		for _, num := range m.PackedNestedEnum {
+			pksize6 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize6
+		j5 := i
+		for _, num1 := range m.PackedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j5] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j5++
+			}
+			dAtA[j5] = uint8(num)
+			j5++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize6))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.PackedBool) > 0 {
+		for iNdEx := len(m.PackedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedBool)))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.PackedDouble) > 0 {
+		for iNdEx := len(m.PackedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f7 := math.Float64bits(float64(m.PackedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f7))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedDouble)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.PackedFloat) > 0 {
+		for iNdEx := len(m.PackedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f8 := math.Float32bits(float32(m.PackedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f8))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFloat)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.PackedSfixed64) > 0 {
+		for iNdEx := len(m.PackedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.PackedSfixed32) > 0 {
+		for iNdEx := len(m.PackedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedSfixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.PackedFixed64) > 0 {
+		for iNdEx := len(m.PackedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed64)*8))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.PackedFixed32) > 0 {
+		for iNdEx := len(m.PackedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedFixed32)*4))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.PackedSint64) > 0 {
+		var pksize10 int
+		for _, num := range m.PackedSint64 {
+			pksize10 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize10
+		j9 := i
+		for _, num := range m.PackedSint64 {
+			x11 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x11 >= 1<<7 {
+				dAtA[j9] = uint8(uint64(x11)&0x7f | 0x80)
+				j9++
+				x11 >>= 7
+			}
+			dAtA[j9] = uint8(x11)
+			j9++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize10))
+		i--
+		dAtA[i] = 0x5
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.PackedSint32) > 0 {
+		var pksize13 int
+		for _, num := range m.PackedSint32 {
+			pksize13 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize13
+		j12 := i
+		for _, num := range m.PackedSint32 {
+			x14 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x14 >= 1<<7 {
+				dAtA[j12] = uint8(uint64(x14)&0x7f | 0x80)
+				j12++
+				x14 >>= 7
+			}
+			dAtA[j12] = uint8(x14)
+			j12++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize13))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xfa
+	}
+	if len(m.PackedUint64) > 0 {
+		var pksize16 int
+		for _, num := range m.PackedUint64 {
+			pksize16 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize16
+		j15 := i
+		for _, num := range m.PackedUint64 {
+			for num >= 1<<7 {
+				dAtA[j15] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j15++
+			}
+			dAtA[j15] = uint8(num)
+			j15++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize16))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xf2
+	}
+	if len(m.PackedUint32) > 0 {
+		var pksize18 int
+		for _, num := range m.PackedUint32 {
+			pksize18 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize18
+		j17 := i
+		for _, num := range m.PackedUint32 {
+			for num >= 1<<7 {
+				dAtA[j17] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j17++
+			}
+			dAtA[j17] = uint8(num)
+			j17++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize18))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.PackedInt64) > 0 {
+		var pksize20 int
+		for _, num := range m.PackedInt64 {
+			pksize20 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize20
+		j19 := i
+		for _, num1 := range m.PackedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j19] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j19++
+			}
+			dAtA[j19] = uint8(num)
+			j19++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize20))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xe2
+	}
+	if len(m.PackedInt32) > 0 {
+		var pksize22 int
+		for _, num := range m.PackedInt32 {
+			pksize22 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize22
+		j21 := i
+		for _, num1 := range m.PackedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j21] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j21++
+			}
+			dAtA[j21] = uint8(num)
+			j21++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize22))
+		i--
+		dAtA[i] = 0x4
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.MapStringForeignEnum) > 0 {
+		keysForMapStringForeignEnum := make([]string, 0, len(m.MapStringForeignEnum))
+		for k := range m.MapStringForeignEnum {
+			keysForMapStringForeignEnum = append(keysForMapStringForeignEnum, string(k))
+		}
+		sort.Slice(keysForMapStringForeignEnum, func(i, j int) bool {
+			return keysForMapStringForeignEnum[i] < keysForMapStringForeignEnum[j]
+		})
+		for iNdEx := len(keysForMapStringForeignEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignEnum[string(keysForMapStringForeignEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringForeignEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapStringNestedEnum) > 0 {
+		keysForMapStringNestedEnum := make([]string, 0, len(m.MapStringNestedEnum))
+		for k := range m.MapStringNestedEnum {
+			keysForMapStringNestedEnum = append(keysForMapStringNestedEnum, string(k))
+		}
+		sort.Slice(keysForMapStringNestedEnum, func(i, j int) bool {
+			return keysForMapStringNestedEnum[i] < keysForMapStringNestedEnum[j]
+		})
+		for iNdEx := len(keysForMapStringNestedEnum) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedEnum[string(keysForMapStringNestedEnum[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(keysForMapStringNestedEnum[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedEnum[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedEnum[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapStringForeignMessage) > 0 {
+		keysForMapStringForeignMessage := make([]string, 0, len(m.MapStringForeignMessage))
+		for k := range m.MapStringForeignMessage {
+			keysForMapStringForeignMessage = append(keysForMapStringForeignMessage, string(k))
+		}
+		sort.Slice(keysForMapStringForeignMessage, func(i, j int) bool {
+			return keysForMapStringForeignMessage[i] < keysForMapStringForeignMessage[j]
+		})
+		for iNdEx := len(keysForMapStringForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringForeignMessage[string(keysForMapStringForeignMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringForeignMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringForeignMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringForeignMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.MapStringNestedMessage) > 0 {
+		keysForMapStringNestedMessage := make([]string, 0, len(m.MapStringNestedMessage))
+		for k := range m.MapStringNestedMessage {
+			keysForMapStringNestedMessage = append(keysForMapStringNestedMessage, string(k))
+		}
+		sort.Slice(keysForMapStringNestedMessage, func(i, j int) bool {
+			return keysForMapStringNestedMessage[i] < keysForMapStringNestedMessage[j]
+		})
+		for iNdEx := len(keysForMapStringNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringNestedMessage[string(keysForMapStringNestedMessage[iNdEx])]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringNestedMessage[iNdEx])
+			copy(dAtA[i:], keysForMapStringNestedMessage[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringNestedMessage[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.MapStringBytes) > 0 {
+		keysForMapStringBytes := make([]string, 0, len(m.MapStringBytes))
+		for k := range m.MapStringBytes {
+			keysForMapStringBytes = append(keysForMapStringBytes, string(k))
+		}
+		sort.Slice(keysForMapStringBytes, func(i, j int) bool {
+			return keysForMapStringBytes[i] < keysForMapStringBytes[j]
+		})
+		for iNdEx := len(keysForMapStringBytes) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringBytes[string(keysForMapStringBytes[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringBytes[iNdEx])
+			copy(dAtA[i:], keysForMapStringBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringBytes[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.MapStringString) > 0 {
+		keysForMapStringString := make([]string, 0, len(m.MapStringString))
+		for k := range m.MapStringString {
+			keysForMapStringString = append(keysForMapStringString, string(k))
+		}
+		sort.Slice(keysForMapStringString, func(i, j int) bool {
+			return keysForMapStringString[i] < keysForMapStringString[j]
+		})
+		for iNdEx := len(keysForMapStringString) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapStringString[string(keysForMapStringString[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForMapStringString[iNdEx])
+			copy(dAtA[i:], keysForMapStringString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForMapStringString[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.MapBoolBool) > 0 {
+		for k := range m.MapBoolBool {
+			v := m.MapBoolBool[bool(k)]
+			baseI := i
+			i--
+			if v {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x10
+			i--
+			if k {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.MapInt32Double) > 0 {
+		keysForMapInt32Double := make([]int32, 0, len(m.MapInt32Double))
+		for k := range m.MapInt32Double {
+			keysForMapInt32Double = append(keysForMapInt32Double, int32(k))
+		}
+		sort.Slice(keysForMapInt32Double, func(i, j int) bool {
+			return keysForMapInt32Double[i] < keysForMapInt32Double[j]
+		})
+		for iNdEx := len(keysForMapInt32Double) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Double[int32(keysForMapInt32Double[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(v))))
+			i--
+			dAtA[i] = 0x11
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Double[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if len(m.MapInt32Float) > 0 {
+		keysForMapInt32Float := make([]int32, 0, len(m.MapInt32Float))
+		for k := range m.MapInt32Float {
+			keysForMapInt32Float = append(keysForMapInt32Float, int32(k))
+		}
+		sort.Slice(keysForMapInt32Float, func(i, j int) bool {
+			return keysForMapInt32Float[i] < keysForMapInt32Float[j]
+		})
+		for iNdEx := len(keysForMapInt32Float) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Float[int32(keysForMapInt32Float[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(v))))
+			i--
+			dAtA[i] = 0x15
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Float[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x92
+		}
+	}
+	if len(m.MapSfixed64Sfixed64) > 0 {
+		keysForMapSfixed64Sfixed64 := make([]int64, 0, len(m.MapSfixed64Sfixed64))
+		for k := range m.MapSfixed64Sfixed64 {
+			keysForMapSfixed64Sfixed64 = append(keysForMapSfixed64Sfixed64, int64(k))
+		}
+		sort.Slice(keysForMapSfixed64Sfixed64, func(i, j int) bool {
+			return keysForMapSfixed64Sfixed64[i] < keysForMapSfixed64Sfixed64[j]
+		})
+		for iNdEx := len(keysForMapSfixed64Sfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed64Sfixed64[int64(keysForMapSfixed64Sfixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapSfixed64Sfixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.MapSfixed32Sfixed32) > 0 {
+		keysForMapSfixed32Sfixed32 := make([]int32, 0, len(m.MapSfixed32Sfixed32))
+		for k := range m.MapSfixed32Sfixed32 {
+			keysForMapSfixed32Sfixed32 = append(keysForMapSfixed32Sfixed32, int32(k))
+		}
+		sort.Slice(keysForMapSfixed32Sfixed32, func(i, j int) bool {
+			return keysForMapSfixed32Sfixed32[i] < keysForMapSfixed32Sfixed32[j]
+		})
+		for iNdEx := len(keysForMapSfixed32Sfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSfixed32Sfixed32[int32(keysForMapSfixed32Sfixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapSfixed32Sfixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.MapFixed64Fixed64) > 0 {
+		keysForMapFixed64Fixed64 := make([]uint64, 0, len(m.MapFixed64Fixed64))
+		for k := range m.MapFixed64Fixed64 {
+			keysForMapFixed64Fixed64 = append(keysForMapFixed64Fixed64, uint64(k))
+		}
+		sort.Slice(keysForMapFixed64Fixed64, func(i, j int) bool {
+			return keysForMapFixed64Fixed64[i] < keysForMapFixed64Fixed64[j]
+		})
+		for iNdEx := len(keysForMapFixed64Fixed64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed64Fixed64[uint64(keysForMapFixed64Fixed64[iNdEx])]
+			baseI := i
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(v))
+			i--
+			dAtA[i] = 0x11
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(keysForMapFixed64Fixed64[iNdEx]))
+			i--
+			dAtA[i] = 0x9
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
+	if len(m.MapFixed32Fixed32) > 0 {
+		keysForMapFixed32Fixed32 := make([]uint32, 0, len(m.MapFixed32Fixed32))
+		for k := range m.MapFixed32Fixed32 {
+			keysForMapFixed32Fixed32 = append(keysForMapFixed32Fixed32, uint32(k))
+		}
+		sort.Slice(keysForMapFixed32Fixed32, func(i, j int) bool {
+			return keysForMapFixed32Fixed32[i] < keysForMapFixed32Fixed32[j]
+		})
+		for iNdEx := len(keysForMapFixed32Fixed32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapFixed32Fixed32[uint32(keysForMapFixed32Fixed32[iNdEx])]
+			baseI := i
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(v))
+			i--
+			dAtA[i] = 0x15
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(keysForMapFixed32Fixed32[iNdEx]))
+			i--
+			dAtA[i] = 0xd
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xf2
+		}
+	}
+	if len(m.MapSint64Sint64) > 0 {
+		keysForMapSint64Sint64 := make([]int64, 0, len(m.MapSint64Sint64))
+		for k := range m.MapSint64Sint64 {
+			keysForMapSint64Sint64 = append(keysForMapSint64Sint64, int64(k))
+		}
+		sort.Slice(keysForMapSint64Sint64, func(i, j int) bool {
+			return keysForMapSint64Sint64[i] < keysForMapSint64Sint64[j]
+		})
+		for iNdEx := len(keysForMapSint64Sint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint64Sint64[int64(keysForMapSint64Sint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(v)<<1)^uint64((v>>63))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(keysForMapSint64Sint64[iNdEx])<<1)^uint64((keysForMapSint64Sint64[iNdEx]>>63))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.MapSint32Sint32) > 0 {
+		keysForMapSint32Sint32 := make([]int32, 0, len(m.MapSint32Sint32))
+		for k := range m.MapSint32Sint32 {
+			keysForMapSint32Sint32 = append(keysForMapSint32Sint32, int32(k))
+		}
+		sort.Slice(keysForMapSint32Sint32, func(i, j int) bool {
+			return keysForMapSint32Sint32[i] < keysForMapSint32Sint32[j]
+		})
+		for iNdEx := len(keysForMapSint32Sint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapSint32Sint32[int32(keysForMapSint32Sint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(v)<<1)^uint32((v>>31))))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(keysForMapSint32Sint32[iNdEx])<<1)^uint32((keysForMapSint32Sint32[iNdEx]>>31))))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.MapUint64Uint64) > 0 {
+		keysForMapUint64Uint64 := make([]uint64, 0, len(m.MapUint64Uint64))
+		for k := range m.MapUint64Uint64 {
+			keysForMapUint64Uint64 = append(keysForMapUint64Uint64, uint64(k))
+		}
+		sort.Slice(keysForMapUint64Uint64, func(i, j int) bool {
+			return keysForMapUint64Uint64[i] < keysForMapUint64Uint64[j]
+		})
+		for iNdEx := len(keysForMapUint64Uint64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint64Uint64[uint64(keysForMapUint64Uint64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint64Uint64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if len(m.MapUint32Uint32) > 0 {
+		keysForMapUint32Uint32 := make([]uint32, 0, len(m.MapUint32Uint32))
+		for k := range m.MapUint32Uint32 {
+			keysForMapUint32Uint32 = append(keysForMapUint32Uint32, uint32(k))
+		}
+		sort.Slice(keysForMapUint32Uint32, func(i, j int) bool {
+			return keysForMapUint32Uint32[i] < keysForMapUint32Uint32[j]
+		})
+		for iNdEx := len(keysForMapUint32Uint32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapUint32Uint32[uint32(keysForMapUint32Uint32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapUint32Uint32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xd2
+		}
+	}
+	if len(m.MapInt64Int64) > 0 {
+		keysForMapInt64Int64 := make([]int64, 0, len(m.MapInt64Int64))
+		for k := range m.MapInt64Int64 {
+			keysForMapInt64Int64 = append(keysForMapInt64Int64, int64(k))
+		}
+		sort.Slice(keysForMapInt64Int64, func(i, j int) bool {
+			return keysForMapInt64Int64[i] < keysForMapInt64Int64[j]
+		})
+		for iNdEx := len(keysForMapInt64Int64) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt64Int64[int64(keysForMapInt64Int64[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt64Int64[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xca
+		}
+	}
+	if len(m.MapInt32Int32) > 0 {
+		keysForMapInt32Int32 := make([]int32, 0, len(m.MapInt32Int32))
+		for k := range m.MapInt32Int32 {
+			keysForMapInt32Int32 = append(keysForMapInt32Int32, int32(k))
+		}
+		sort.Slice(keysForMapInt32Int32, func(i, j int) bool {
+			return keysForMapInt32Int32[i] < keysForMapInt32Int32[j]
+		})
+		for iNdEx := len(keysForMapInt32Int32) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.MapInt32Int32[int32(keysForMapInt32Int32[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForMapInt32Int32[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.RepeatedCord) > 0 {
+		for iNdEx := len(m.RepeatedCord) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedCord[iNdEx])
+			copy(dAtA[i:], m.RepeatedCord[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedCord[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.RepeatedStringPiece) > 0 {
+		for iNdEx := len(m.RepeatedStringPiece) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedStringPiece[iNdEx])
+			copy(dAtA[i:], m.RepeatedStringPiece[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedStringPiece[iNdEx])))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if len(m.RepeatedForeignEnum) > 0 {
+		var pksize24 int
+		for _, num := range m.RepeatedForeignEnum {
+			pksize24 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize24
+		j23 := i
+		for _, num1 := range m.RepeatedForeignEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j23] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j23++
+			}
+			dAtA[j23] = uint8(num)
+			j23++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize24))
+		i--
+		dAtA[i] = 0x3
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.RepeatedNestedEnum) > 0 {
+		var pksize26 int
+		for _, num := range m.RepeatedNestedEnum {
+			pksize26 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize26
+		j25 := i
+		for _, num1 := range m.RepeatedNestedEnum {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j25] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j25++
+			}
+			dAtA[j25] = uint8(num)
+			j25++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize26))
+		i--
+		dAtA[i] = 0x3
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.RepeatedForeignMessage) > 0 {
+		for iNdEx := len(m.RepeatedForeignMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedForeignMessage[iNdEx].MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if len(m.RepeatedNestedMessage) > 0 {
+		for iNdEx := len(m.RepeatedNestedMessage) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepeatedNestedMessage[iNdEx].MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.RepeatedBytes) > 0 {
+		for iNdEx := len(m.RepeatedBytes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedBytes[iNdEx])
+			copy(dAtA[i:], m.RepeatedBytes[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBytes[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xea
+		}
+	}
+	if len(m.RepeatedString) > 0 {
+		for iNdEx := len(m.RepeatedString) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedString[iNdEx])
+			copy(dAtA[i:], m.RepeatedString[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedString[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.RepeatedBool) > 0 {
+		for iNdEx := len(m.RepeatedBool) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedBool[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedBool)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.RepeatedDouble) > 0 {
+		for iNdEx := len(m.RepeatedDouble) - 1; iNdEx >= 0; iNdEx-- {
+			f27 := math.Float64bits(float64(m.RepeatedDouble[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f27))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedDouble)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xd2
+	}
+	if len(m.RepeatedFloat) > 0 {
+		for iNdEx := len(m.RepeatedFloat) - 1; iNdEx >= 0; iNdEx-- {
+			f28 := math.Float32bits(float32(m.RepeatedFloat[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f28))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFloat)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xca
+	}
+	if len(m.RepeatedSfixed64) > 0 {
+		for iNdEx := len(m.RepeatedSfixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedSfixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedSfixed64)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xc2
+	}
+	if len(m.RepeatedSfixed32) > 0 {
+		for iNdEx := len(m.RepeatedSfixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedSfixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedSfixed32)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.RepeatedFixed64) > 0 {
+		for iNdEx := len(m.RepeatedFixed64) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedFixed64[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFixed64)*8))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xb2
+	}
+	if len(m.RepeatedFixed32) > 0 {
+		for iNdEx := len(m.RepeatedFixed32) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedFixed32[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedFixed32)*4))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xaa
+	}
+	if len(m.RepeatedSint64) > 0 {
+		var pksize30 int
+		for _, num := range m.RepeatedSint64 {
+			pksize30 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize30
+		j29 := i
+		for _, num := range m.RepeatedSint64 {
+			x31 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x31 >= 1<<7 {
+				dAtA[j29] = uint8(uint64(x31)&0x7f | 0x80)
+				j29++
+				x31 >>= 7
+			}
+			dAtA[j29] = uint8(x31)
+			j29++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize30))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.RepeatedSint32) > 0 {
+		var pksize33 int
+		for _, num := range m.RepeatedSint32 {
+			pksize33 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize33
+		j32 := i
+		for _, num := range m.RepeatedSint32 {
+			x34 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x34 >= 1<<7 {
+				dAtA[j32] = uint8(uint64(x34)&0x7f | 0x80)
+				j32++
+				x34 >>= 7
+			}
+			dAtA[j32] = uint8(x34)
+			j32++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize33))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.RepeatedUint64) > 0 {
+		var pksize36 int
+		for _, num := range m.RepeatedUint64 {
+			pksize36 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize36
+		j35 := i
+		for _, num := range m.RepeatedUint64 {
+			for num >= 1<<7 {
+				dAtA[j35] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j35++
+			}
+			dAtA[j35] = uint8(num)
+			j35++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize36))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.RepeatedUint32) > 0 {
+		var pksize38 int
+		for _, num := range m.RepeatedUint32 {
+			pksize38 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize38
+		j37 := i
+		for _, num := range m.RepeatedUint32 {
+			for num >= 1<<7 {
+				dAtA[j37] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j37++
+			}
+			dAtA[j37] = uint8(num)
+			j37++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize38))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.RepeatedInt64) > 0 {
+		var pksize40 int
+		for _, num := range m.RepeatedInt64 {
+			pksize40 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize40
+		j39 := i
+		for _, num1 := range m.RepeatedInt64 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j39] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j39++
+			}
+			dAtA[j39] = uint8(num)
+			j39++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize40))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x82
+	}
+	if len(m.RepeatedInt32) > 0 {
+		var pksize42 int
+		for _, num := range m.RepeatedInt32 {
+			pksize42 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize42
+		j41 := i
+		for _, num1 := range m.RepeatedInt32 {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j41] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j41++
+			}
+			dAtA[j41] = uint8(num)
+			j41++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize42))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xfa
+	}
+	if m.RecursiveMessage != nil {
+		size, err := m.RecursiveMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.OptionalCord) > 0 {
+		i -= len(m.OptionalCord)
+		copy(dAtA[i:], m.OptionalCord)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalCord)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	if len(m.OptionalStringPiece) > 0 {
+		i -= len(m.OptionalStringPiece)
+		copy(dAtA[i:], m.OptionalStringPiece)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalStringPiece)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
+	if m.OptionalAliasedEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalAliasedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.OptionalForeignEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalForeignEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.OptionalNestedEnum != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalNestedEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.OptionalForeignMessage != nil {
+		size, err := m.OptionalForeignMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
+	if m.OptionalNestedMessage != nil {
+		size, err := m.OptionalNestedMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.OptionalBytes) > 0 {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if len(m.OptionalString) > 0 {
+		i -= len(m.OptionalString)
+		copy(dAtA[i:], m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool {
+		i--
+		if m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(m.OptionalSint64)<<1)^uint64((m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(m.OptionalSint32)<<1)^uint32((m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestAllTypesProto3_OneofUint32) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofUint32) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint32))
+	i--
+	dAtA[i] = 0x6
+	i--
+	dAtA[i] = 0xf8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofNestedMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofNestedMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.OneofNestedMessage != nil {
+		size, err := m.OneofNestedMessage.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7
+		i--
+		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofString) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofString) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofString)
+	copy(dAtA[i:], m.OneofString)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofString)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x8a
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofBytes) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofBytes) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.OneofBytes)
+	copy(dAtA[i:], m.OneofBytes)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OneofBytes)))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x92
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofBool) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofBool) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.OneofBool {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0x98
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofUint64) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofUint64) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofUint64))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xa0
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofFloat) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofFloat) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 4
+	binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.OneofFloat))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xad
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofDouble) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofDouble) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.OneofDouble))))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb1
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofEnum) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofEnum) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofEnum))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xb8
+	return len(dAtA) - i, nil
+}
+func (m *TestAllTypesProto3_OneofNullValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestAllTypesProto3_OneofNullValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OneofNullValue))
+	i--
+	dAtA[i] = 0x7
+	i--
+	dAtA[i] = 0xc0
+	return len(dAtA) - i, nil
+}
+func (m *ForeignMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ForeignMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ForeignMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.C))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NullHypothesisProto3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NullHypothesisProto3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *NullHypothesisProto3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumOnlyProto3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumOnlyProto3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *EnumOnlyProto3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}

--- a/features/marshal/marshalto.go
+++ b/features/marshal/marshalto.go
@@ -25,6 +25,12 @@ func init() {
 	generator.RegisterFeature("marshal_strict", func(gen *generator.GeneratedFile) generator.FeatureGenerator {
 		return &marshal{GeneratedFile: gen, Stable: false, strict: true}
 	})
+	generator.RegisterFeature("marshal_stable", func(gen *generator.GeneratedFile) generator.FeatureGenerator {
+		return &marshal{GeneratedFile: gen, Stable: true, strict: false}
+	})
+	generator.RegisterFeature("marshal_stable_strict", func(gen *generator.GeneratedFile) generator.FeatureGenerator {
+		return &marshal{GeneratedFile: gen, Stable: true, strict: true}
+	})
 }
 
 type counter int
@@ -527,8 +533,12 @@ func (p *marshal) field(oneof bool, numGen *counter, field *protogen.Field) {
 
 func (p *marshal) methodMarshalToSizedBuffer() string {
 	switch {
-	case p.strict:
+	case p.strict && !p.Stable:
 		return "MarshalToSizedBufferVTStrict"
+	case !p.strict && p.Stable:
+		return "MarshalToSizedBufferVTStable"
+	case p.strict && p.Stable:
+		return "MarshalToSizedBufferVTStableStrict"
 	default:
 		return "MarshalToSizedBufferVT"
 	}
@@ -536,8 +546,12 @@ func (p *marshal) methodMarshalToSizedBuffer() string {
 
 func (p *marshal) methodMarshalTo() string {
 	switch {
-	case p.strict:
+	case p.strict && !p.Stable:
 		return "MarshalToVTStrict"
+	case !p.strict && p.Stable:
+		return "MarshalToVTStable"
+	case p.strict && p.Stable:
+		return "MarshalToVTStableStrict"
 	default:
 		return "MarshalToVT"
 	}
@@ -545,8 +559,12 @@ func (p *marshal) methodMarshalTo() string {
 
 func (p *marshal) methodMarshal() string {
 	switch {
-	case p.strict:
+	case p.strict && !p.Stable:
 		return "MarshalVTStrict"
+	case !p.strict && p.Stable:
+		return "MarshalVTStable"
+	case p.strict && p.Stable:
+		return "MarshalVTStableStrict"
 	default:
 		return "MarshalVT"
 	}

--- a/testproto/grpc/grpc_vtproto.pb.go
+++ b/testproto/grpc/grpc_vtproto.pb.go
@@ -333,6 +333,138 @@ func (m *LocalTestMessageResponse) MarshalToSizedBufferVT(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *LocalTestMessageRequest) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LocalTestMessageRequest) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *LocalTestMessageRequest) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *LocalTestMessageResponse) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LocalTestMessageResponse) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *LocalTestMessageResponse) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *LocalTestMessageRequest) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LocalTestMessageRequest) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *LocalTestMessageRequest) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *LocalTestMessageResponse) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LocalTestMessageResponse) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *LocalTestMessageResponse) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *LocalTestMessageRequest) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/grpc/inner/inner_vtproto.pb.go
+++ b/testproto/grpc/inner/inner_vtproto.pb.go
@@ -150,6 +150,138 @@ func (m *TestMessageResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TestMessageRequest) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestMessageRequest) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestMessageRequest) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestMessageResponse) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestMessageResponse) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *TestMessageResponse) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestMessageRequest) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestMessageRequest) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestMessageRequest) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TestMessageResponse) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestMessageResponse) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *TestMessageResponse) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *TestMessageRequest) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/pool/pool_vtproto.pb.go
+++ b/testproto/pool/pool_vtproto.pb.go
@@ -185,6 +185,182 @@ func (m *MemoryPoolExtension) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *OptionalMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OptionalMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MemoryPoolExtension) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MemoryPoolExtension) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *MemoryPoolExtension) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Foo3 != nil {
+		size, err := m.Foo3.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Foo2 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Foo2))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Foo1) > 0 {
+		i -= len(m.Foo1)
+		copy(dAtA[i:], m.Foo1)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Foo1)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OptionalMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OptionalMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MemoryPoolExtension) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MemoryPoolExtension) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *MemoryPoolExtension) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Foo3 != nil {
+		size, err := m.Foo3.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Foo2 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Foo2))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Foo1) > 0 {
+		i -= len(m.Foo1)
+		copy(dAtA[i:], m.Foo1)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Foo1)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *OptionalMessage) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/pool/pool_with_oneof_vtproto.pb.go
+++ b/testproto/pool/pool_with_oneof_vtproto.pb.go
@@ -626,6 +626,573 @@ func (m *OneofTest_Test4) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	return len(dAtA) - i, nil
 }
+func (m *OneofTest_Test1) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test1) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test1) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		for iNdEx := len(m.B) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.B[iNdEx])
+			copy(dAtA[i:], m.B[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test3_Element2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test3_Element2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test3_Element2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.D != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.D))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != nil {
+		size, err := m.C.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Test.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test1_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test1_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test1 != nil {
+		size, err := m.Test1.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test2_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test2_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test2 != nil {
+		size, err := m.Test2.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test3_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test3_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test3 != nil {
+		size, err := m.Test3.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test4) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OneofTest_Test4) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.Test4)
+	copy(dAtA[i:], m.Test4)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Test4)))
+	i--
+	dAtA[i] = 0x22
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test1) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test1) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test1) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		for iNdEx := len(m.B) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.B[iNdEx])
+			copy(dAtA[i:], m.B[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test3_Element2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test3_Element2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test3_Element2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.D != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.D))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest_Test3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.C != nil {
+		size, err := m.C.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OneofTest) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if msg, ok := m.Test.(*OneofTest_Test4); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Test.(*OneofTest_Test3_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Test.(*OneofTest_Test2_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Test.(*OneofTest_Test1_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OneofTest_Test1_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test1_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test1 != nil {
+		size, err := m.Test1.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test2_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test2_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test2 != nil {
+		size, err := m.Test2.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test3_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test3_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Test3 != nil {
+		size, err := m.Test3.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *OneofTest_Test4) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OneofTest_Test4) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.Test4)
+	copy(dAtA[i:], m.Test4)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Test4)))
+	i--
+	dAtA[i] = 0x22
+	return len(dAtA) - i, nil
+}
 func (m *OneofTest_Test1) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
+++ b/testproto/pool/pool_with_slice_reuse_vtproto.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
+	sort "sort"
 	sync "sync"
 	unsafe "unsafe"
 )
@@ -433,6 +434,438 @@ func (m *Element2) MarshalToVT(dAtA []byte) (int, error) {
 }
 
 func (m *Element2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Test1) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Test1) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Test1) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Sl) > 0 {
+		for iNdEx := len(m.Sl) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Sl[iNdEx])
+			copy(dAtA[i:], m.Sl[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Sl[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Test2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Test2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Test2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Sl) > 0 {
+		for iNdEx := len(m.Sl) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Sl[iNdEx].MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Slice2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Slice2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Slice2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.F != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.F))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.E) > 0 {
+		i -= len(m.E)
+		copy(dAtA[i:], m.E)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.E)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.D != nil {
+		size, err := m.D.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.C) > 0 {
+		for iNdEx := len(m.C) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.C[iNdEx])
+			copy(dAtA[i:], m.C[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.C[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.B != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.B))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.A) > 0 {
+		keysForA := make([]int64, 0, len(m.A))
+		for k := range m.A {
+			keysForA = append(keysForA, int64(k))
+		}
+		sort.Slice(keysForA, func(i, j int) bool {
+			return keysForA[i] < keysForA[j]
+		})
+		for iNdEx := len(keysForA) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.A[int64(keysForA[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForA[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Element2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Element2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Element2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.A != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Test1) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Test1) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Test1) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Sl) > 0 {
+		for iNdEx := len(m.Sl) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Sl[iNdEx])
+			copy(dAtA[i:], m.Sl[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Sl[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Test2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Test2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Test2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Sl) > 0 {
+		for iNdEx := len(m.Sl) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Sl[iNdEx].MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Slice2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Slice2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Slice2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.F != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.F))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.E) > 0 {
+		i -= len(m.E)
+		copy(dAtA[i:], m.E)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.E)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.D != nil {
+		size, err := m.D.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.C) > 0 {
+		for iNdEx := len(m.C) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.C[iNdEx])
+			copy(dAtA[i:], m.C[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.C[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.B != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.B))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.A) > 0 {
+		keysForA := make([]int64, 0, len(m.A))
+		for k := range m.A {
+			keysForA = append(keysForA, int64(k))
+		}
+		sort.Slice(keysForA, func(i, j int) bool {
+			return keysForA[i] < keysForA[j]
+		})
+		for iNdEx := len(keysForA) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.A[int64(keysForA[iNdEx])]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(keysForA[iNdEx]))
+			i--
+			dAtA[i] = 0x8
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Element2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Element2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Element2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}

--- a/testproto/proto2/scalars_vtproto.pb.go
+++ b/testproto/proto2/scalars_vtproto.pb.go
@@ -2279,6 +2279,2196 @@ func (m *EnumMessage) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *DoubleMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DoubleMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *DoubleMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.PackedField[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float64bits(float64(m.RepeatedField[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f2))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalField))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.RequiredField))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FloatMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FloatMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *FloatMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float32bits(float32(m.PackedField[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f1))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.RepeatedField[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalField))))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.RequiredField))))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int32Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int32Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Int32Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int64Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int64Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Int64Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Uint32Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Uint32Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Uint32Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Uint64Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Uint64Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Uint64Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sint32Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sint32Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Sint32Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			x3 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x3 >= 1<<7 {
+				dAtA[j1] = uint8(uint64(x3)&0x7f | 0x80)
+				j1++
+				x3 >>= 7
+			}
+			dAtA[j1] = uint8(x3)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.RepeatedField[iNdEx]) << 1) ^ uint32((m.RepeatedField[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalField)<<1)^uint32((*m.OptionalField>>31))))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.RequiredField)<<1)^uint32((*m.RequiredField>>31))))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sint64Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sint64Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Sint64Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			x3 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x3 >= 1<<7 {
+				dAtA[j1] = uint8(uint64(x3)&0x7f | 0x80)
+				j1++
+				x3 >>= 7
+			}
+			dAtA[j1] = uint8(x3)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint64(m.RepeatedField[iNdEx]) << 1) ^ uint64((m.RepeatedField[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalField)<<1)^uint64((*m.OptionalField>>63))))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.RequiredField)<<1)^uint64((*m.RequiredField>>63))))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Fixed32Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Fixed32Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Fixed32Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalField))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.RequiredField))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Fixed64Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Fixed64Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Fixed64Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sfixed32Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sfixed32Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Sfixed32Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalField))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.RequiredField))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sfixed64Message) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sfixed64Message) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Sfixed64Message) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BoolMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BoolMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *BoolMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedField[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedField[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i--
+		if *m.OptionalField {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i--
+		if *m.RequiredField {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *StringMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedField[iNdEx])
+			copy(dAtA[i:], m.RepeatedField[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedField[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.OptionalField != nil {
+		i -= len(*m.OptionalField)
+		copy(dAtA[i:], *m.OptionalField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalField)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= len(*m.RequiredField)
+		copy(dAtA[i:], *m.RequiredField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.RequiredField)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BytesMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BytesMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *BytesMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedField[iNdEx])
+			copy(dAtA[i:], m.RepeatedField[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedField[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.OptionalField != nil {
+		i -= len(m.OptionalField)
+		copy(dAtA[i:], m.OptionalField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalField)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= len(m.RequiredField)
+		copy(dAtA[i:], m.RequiredField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredField)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumMessage) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumMessage) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *EnumMessage) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DoubleMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DoubleMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *DoubleMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.PackedField[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float64bits(float64(m.RepeatedField[iNdEx]))
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(f2))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalField))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.RequiredField))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FloatMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FloatMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *FloatMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float32bits(float32(m.PackedField[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f1))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			f2 := math.Float32bits(float32(m.RepeatedField[iNdEx]))
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(f2))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalField))))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.RequiredField))))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int32Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int32Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Int32Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int64Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int64Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Int64Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Uint32Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Uint32Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Uint32Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Uint64Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Uint64Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Uint64Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sint32Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sint32Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Sint32Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			x3 := (uint32(num) << 1) ^ uint32((num >> 31))
+			for x3 >= 1<<7 {
+				dAtA[j1] = uint8(uint64(x3)&0x7f | 0x80)
+				j1++
+				x3 >>= 7
+			}
+			dAtA[j1] = uint8(x3)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint32(m.RepeatedField[iNdEx]) << 1) ^ uint32((m.RepeatedField[iNdEx] >> 31))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalField)<<1)^uint32((*m.OptionalField>>31))))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.RequiredField)<<1)^uint32((*m.RequiredField>>31))))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sint64Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sint64Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Sint64Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfZigzag(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.PackedField {
+			x3 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x3 >= 1<<7 {
+				dAtA[j1] = uint8(uint64(x3)&0x7f | 0x80)
+				j1++
+				x3 >>= 7
+			}
+			dAtA[j1] = uint8(x3)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			x4 := (uint64(m.RepeatedField[iNdEx]) << 1) ^ uint64((m.RepeatedField[iNdEx] >> 63))
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(x4))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalField)<<1)^uint64((*m.OptionalField>>63))))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.RequiredField)<<1)^uint64((*m.RequiredField>>63))))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Fixed32Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Fixed32Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Fixed32Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalField))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.RequiredField))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Fixed64Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Fixed64Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Fixed64Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sfixed32Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sfixed32Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Sfixed32Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x1d
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalField))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.RequiredField))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Sfixed64Message) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Sfixed64Message) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Sfixed64Message) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.PackedField[iNdEx]))
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)*8))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= 8
+			binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x19
+		}
+	}
+	if m.OptionalField != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BoolMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BoolMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *BoolMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		for iNdEx := len(m.PackedField) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.PackedField[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PackedField)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i--
+			if m.RepeatedField[iNdEx] {
+				dAtA[i] = 1
+			} else {
+				dAtA[i] = 0
+			}
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i--
+		if *m.OptionalField {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i--
+		if *m.RequiredField {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *StringMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedField[iNdEx])
+			copy(dAtA[i:], m.RepeatedField[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedField[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.OptionalField != nil {
+		i -= len(*m.OptionalField)
+		copy(dAtA[i:], *m.OptionalField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalField)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= len(*m.RequiredField)
+		copy(dAtA[i:], *m.RequiredField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.RequiredField)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BytesMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BytesMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *BytesMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RepeatedField[iNdEx])
+			copy(dAtA[i:], m.RepeatedField[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RepeatedField[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.OptionalField != nil {
+		i -= len(m.OptionalField)
+		copy(dAtA[i:], m.OptionalField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalField)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i -= len(m.RequiredField)
+		copy(dAtA[i:], m.RequiredField)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredField)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnumMessage) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnumMessage) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *EnumMessage) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PackedField) > 0 {
+		var pksize2 int
+		for _, num := range m.PackedField {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.PackedField {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RepeatedField) > 0 {
+		for iNdEx := len(m.RepeatedField) - 1; iNdEx >= 0; iNdEx-- {
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RepeatedField[iNdEx]))
+			i--
+			dAtA[i] = 0x18
+		}
+	}
+	if m.OptionalField != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalField))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RequiredField == nil {
+		return 0, fmt.Errorf("proto: required field required_field not set")
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RequiredField))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *DoubleMessage) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/proto3opt/opt_vtproto.pb.go
+++ b/testproto/proto3opt/opt_vtproto.pb.go
@@ -297,6 +297,266 @@ func (m *OptionalFieldInProto3) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 
+func (m *OptionalFieldInProto3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalFieldInProto3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *OptionalFieldInProto3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.OptionalEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.OptionalBytes != nil {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalSint64)<<1)^uint64((*m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalSint32)<<1)^uint32((*m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OptionalFieldInProto3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OptionalFieldInProto3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *OptionalFieldInProto3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.OptionalEnum != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalEnum))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.OptionalBytes != nil {
+		i -= len(m.OptionalBytes)
+		copy(dAtA[i:], m.OptionalBytes)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.OptionalBytes)))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.OptionalString != nil {
+		i -= len(*m.OptionalString)
+		copy(dAtA[i:], *m.OptionalString)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.OptionalString)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.OptionalBool != nil {
+		i--
+		if *m.OptionalBool {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.OptionalDouble != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(*m.OptionalDouble))))
+		i--
+		dAtA[i] = 0x61
+	}
+	if m.OptionalFloat != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(*m.OptionalFloat))))
+		i--
+		dAtA[i] = 0x5d
+	}
+	if m.OptionalSfixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalSfixed64))
+		i--
+		dAtA[i] = 0x51
+	}
+	if m.OptionalSfixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalSfixed32))
+		i--
+		dAtA[i] = 0x4d
+	}
+	if m.OptionalFixed64 != nil {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(*m.OptionalFixed64))
+		i--
+		dAtA[i] = 0x41
+	}
+	if m.OptionalFixed32 != nil {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(*m.OptionalFixed32))
+		i--
+		dAtA[i] = 0x3d
+	}
+	if m.OptionalSint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint64(*m.OptionalSint64)<<1)^uint64((*m.OptionalSint64>>63))))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.OptionalSint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64((uint32(*m.OptionalSint32)<<1)^uint32((*m.OptionalSint32>>31))))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.OptionalUint64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint64))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.OptionalUint32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalUint32))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.OptionalInt64 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt64))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.OptionalInt32 != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OptionalInt32))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *OptionalFieldInProto3) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/testproto/unsafe/unsafe_vtproto.pb.go
+++ b/testproto/unsafe/unsafe_vtproto.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
+	sort "sort"
 	unsafe "unsafe"
 )
 
@@ -949,6 +950,883 @@ func (m *UnsafeTest_Sub5_) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	if m.Sub5 != nil {
 		size, err := m.Sub5.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub1) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub1) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub1) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		i -= len(m.B)
+		copy(dAtA[i:], m.B)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.S) > 0 {
+		i -= len(m.S)
+		copy(dAtA[i:], m.S)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub2) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub2) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub2) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		for iNdEx := len(m.B) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.B[iNdEx])
+			copy(dAtA[i:], m.B[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.S) > 0 {
+		for iNdEx := len(m.S) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.S[iNdEx])
+			copy(dAtA[i:], m.S[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub3) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub3) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub3) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Foo) > 0 {
+		keysForFoo := make([]string, 0, len(m.Foo))
+		for k := range m.Foo {
+			keysForFoo = append(keysForFoo, string(k))
+		}
+		sort.Slice(keysForFoo, func(i, j int) bool {
+			return keysForFoo[i] < keysForFoo[j]
+		})
+		for iNdEx := len(keysForFoo) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Foo[string(keysForFoo[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFoo[iNdEx])
+			copy(dAtA[i:], keysForFoo[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFoo[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub4) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub4) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Foo.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub4_S) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_S) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.S)
+	copy(dAtA[i:], m.S)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub4_B) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_B) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.B)
+	copy(dAtA[i:], m.B)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub5) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub5) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub5) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Foo) > 0 {
+		keysForFoo := make([]string, 0, len(m.Foo))
+		for k := range m.Foo {
+			keysForFoo = append(keysForFoo, string(k))
+		}
+		sort.Slice(keysForFoo, func(i, j int) bool {
+			return keysForFoo[i] < keysForFoo[j]
+		})
+		for iNdEx := len(keysForFoo) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Foo[string(keysForFoo[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFoo[iNdEx])
+			copy(dAtA[i:], keysForFoo[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFoo[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Sub.(interface {
+		MarshalToSizedBufferVTStable([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub1_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub1_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub1 != nil {
+		size, err := m.Sub1.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub2_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub2_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub2 != nil {
+		size, err := m.Sub2.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub3_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub3_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub3 != nil {
+		size, err := m.Sub3.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub4_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub4 != nil {
+		size, err := m.Sub4.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub5_) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub5_) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub5 != nil {
+		size, err := m.Sub5.MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub1) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub1) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub1) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		i -= len(m.B)
+		copy(dAtA[i:], m.B)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.S) > 0 {
+		i -= len(m.S)
+		copy(dAtA[i:], m.S)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub2) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub2) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub2) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.B) > 0 {
+		for iNdEx := len(m.B) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.B[iNdEx])
+			copy(dAtA[i:], m.B[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.S) > 0 {
+		for iNdEx := len(m.S) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.S[iNdEx])
+			copy(dAtA[i:], m.S[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub3) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub3) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub3) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Foo) > 0 {
+		keysForFoo := make([]string, 0, len(m.Foo))
+		for k := range m.Foo {
+			keysForFoo = append(keysForFoo, string(k))
+		}
+		sort.Slice(keysForFoo, func(i, j int) bool {
+			return keysForFoo[i] < keysForFoo[j]
+		})
+		for iNdEx := len(keysForFoo) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Foo[string(keysForFoo[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFoo[iNdEx])
+			copy(dAtA[i:], keysForFoo[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFoo[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub4) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub4) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if msg, ok := m.Foo.(*UnsafeTest_Sub4_B); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Foo.(*UnsafeTest_Sub4_S); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub4_S) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_S) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.S)
+	copy(dAtA[i:], m.S)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.S)))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub4_B) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_B) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.B)
+	copy(dAtA[i:], m.B)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.B)))
+	i--
+	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub5) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest_Sub5) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub5) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Foo) > 0 {
+		keysForFoo := make([]string, 0, len(m.Foo))
+		for k := range m.Foo {
+			keysForFoo = append(keysForFoo, string(k))
+		}
+		sort.Slice(keysForFoo, func(i, j int) bool {
+			return keysForFoo[i] < keysForFoo[j]
+		})
+		for iNdEx := len(keysForFoo) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Foo[string(keysForFoo[iNdEx])]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFoo[iNdEx])
+			copy(dAtA[i:], keysForFoo[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFoo[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnsafeTest) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if msg, ok := m.Sub.(*UnsafeTest_Sub5_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Sub.(*UnsafeTest_Sub4_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Sub.(*UnsafeTest_Sub3_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Sub.(*UnsafeTest_Sub2_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if msg, ok := m.Sub.(*UnsafeTest_Sub1_); ok {
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnsafeTest_Sub1_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub1_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub1 != nil {
+		size, err := m.Sub1.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub2_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub2_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub2 != nil {
+		size, err := m.Sub2.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub3_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub3_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub3 != nil {
+		size, err := m.Sub3.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub4_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub4_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub4 != nil {
+		size, err := m.Sub4.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
+func (m *UnsafeTest_Sub5_) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UnsafeTest_Sub5_) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Sub5 != nil {
+		size, err := m.Sub5.MarshalToSizedBufferVTStableStrict(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}

--- a/testproto/wkt/wkt_vtproto.pb.go
+++ b/testproto/wkt/wkt_vtproto.pb.go
@@ -351,6 +351,434 @@ func (m *MessageWithWKT) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MessageWithWKT) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MessageWithWKT) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *MessageWithWKT) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.NullValue != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NullValue))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.ListvalueValue != nil {
+		size, err := (*structpb1.ListValue)(m.ListvalueValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.ValueValue != nil {
+		size, err := (*structpb1.Value)(m.ValueValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.StructValue != nil {
+		size, err := (*structpb1.Struct)(m.StructValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.BytesValue != nil {
+		size, err := (*wrapperspb1.BytesValue)(m.BytesValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.StringValue != nil {
+		size, err := (*wrapperspb1.StringValue)(m.StringValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x6a
+	}
+	if m.BoolValue != nil {
+		size, err := (*wrapperspb1.BoolValue)(m.BoolValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x62
+	}
+	if m.Uint32Value != nil {
+		size, err := (*wrapperspb1.UInt32Value)(m.Uint32Value).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x5a
+	}
+	if m.Int32Value != nil {
+		size, err := (*wrapperspb1.Int32Value)(m.Int32Value).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x52
+	}
+	if m.Uint64Value != nil {
+		size, err := (*wrapperspb1.UInt64Value)(m.Uint64Value).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.Int64Value != nil {
+		size, err := (*wrapperspb1.Int64Value)(m.Int64Value).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.FloatValue != nil {
+		size, err := (*wrapperspb1.FloatValue)(m.FloatValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if m.DoubleValue != nil {
+		size, err := (*wrapperspb1.DoubleValue)(m.DoubleValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.Timestamp != nil {
+		size, err := (*timestamppb1.Timestamp)(m.Timestamp).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.FieldMask != nil {
+		size, err := (*fieldmaskpb1.FieldMask)(m.FieldMask).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Empty != nil {
+		size, err := (*emptypb1.Empty)(m.Empty).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Duration != nil {
+		size, err := (*durationpb1.Duration)(m.Duration).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Any != nil {
+		size, err := (*anypb1.Any)(m.Any).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MessageWithWKT) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MessageWithWKT) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *MessageWithWKT) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.NullValue != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NullValue))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
+	}
+	if m.ListvalueValue != nil {
+		size, err := (*structpb1.ListValue)(m.ListvalueValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.ValueValue != nil {
+		size, err := (*structpb1.Value)(m.ValueValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.StructValue != nil {
+		size, err := (*structpb1.Struct)(m.StructValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.BytesValue != nil {
+		size, err := (*wrapperspb1.BytesValue)(m.BytesValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.StringValue != nil {
+		size, err := (*wrapperspb1.StringValue)(m.StringValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x6a
+	}
+	if m.BoolValue != nil {
+		size, err := (*wrapperspb1.BoolValue)(m.BoolValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x62
+	}
+	if m.Uint32Value != nil {
+		size, err := (*wrapperspb1.UInt32Value)(m.Uint32Value).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x5a
+	}
+	if m.Int32Value != nil {
+		size, err := (*wrapperspb1.Int32Value)(m.Int32Value).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x52
+	}
+	if m.Uint64Value != nil {
+		size, err := (*wrapperspb1.UInt64Value)(m.Uint64Value).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.Int64Value != nil {
+		size, err := (*wrapperspb1.Int64Value)(m.Int64Value).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.FloatValue != nil {
+		size, err := (*wrapperspb1.FloatValue)(m.FloatValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if m.DoubleValue != nil {
+		size, err := (*wrapperspb1.DoubleValue)(m.DoubleValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.Timestamp != nil {
+		size, err := (*timestamppb1.Timestamp)(m.Timestamp).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.FieldMask != nil {
+		size, err := (*fieldmaskpb1.FieldMask)(m.FieldMask).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Empty != nil {
+		size, err := (*emptypb1.Empty)(m.Empty).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Duration != nil {
+		size, err := (*durationpb1.Duration)(m.Duration).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Any != nil {
+		size, err := (*anypb1.Any)(m.Any).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *MessageWithWKT) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/anypb/any_vtproto.pb.go
+++ b/types/known/anypb/any_vtproto.pb.go
@@ -94,6 +94,92 @@ func (m *Any) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Any) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Any) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Any) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.TypeUrl) > 0 {
+		i -= len(m.TypeUrl)
+		copy(dAtA[i:], m.TypeUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TypeUrl)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Any) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Any) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Any) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.TypeUrl) > 0 {
+		i -= len(m.TypeUrl)
+		copy(dAtA[i:], m.TypeUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TypeUrl)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Any) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/durationpb/duration_vtproto.pb.go
+++ b/types/known/durationpb/duration_vtproto.pb.go
@@ -85,6 +85,84 @@ func (m *Duration) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Duration) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Duration) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Duration) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Nanos != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Nanos))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Seconds != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Seconds))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Duration) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Duration) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Duration) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Nanos != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Nanos))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Seconds != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Seconds))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Duration) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/emptypb/empty_vtproto.pb.go
+++ b/types/known/emptypb/empty_vtproto.pb.go
@@ -67,6 +67,64 @@ func (m *Empty) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Empty) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Empty) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Empty) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *Empty) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Empty) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Empty) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func (m *Empty) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/fieldmaskpb/field_mask_vtproto.pb.go
+++ b/types/known/fieldmaskpb/field_mask_vtproto.pb.go
@@ -91,6 +91,82 @@ func (m *FieldMask) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *FieldMask) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FieldMask) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *FieldMask) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Paths) > 0 {
+		for iNdEx := len(m.Paths) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Paths[iNdEx])
+			copy(dAtA[i:], m.Paths[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Paths[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FieldMask) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FieldMask) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *FieldMask) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Paths) > 0 {
+		for iNdEx := len(m.Paths) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Paths[iNdEx])
+			copy(dAtA[i:], m.Paths[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Paths[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *FieldMask) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/structpb/struct_vtproto.pb.go
+++ b/types/known/structpb/struct_vtproto.pb.go
@@ -12,6 +12,7 @@ import (
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	io "io"
 	math "math"
+	sort "sort"
 	unsafe "unsafe"
 )
 
@@ -620,6 +621,536 @@ func (m *ListValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if len(m.Values) > 0 {
 		for iNdEx := len(m.Values) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := (*Value)(m.Values[iNdEx]).MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Struct) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Struct) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Struct) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Fields) > 0 {
+		keysForFields := make([]string, 0, len(m.Fields))
+		for k := range m.Fields {
+			keysForFields = append(keysForFields, string(k))
+		}
+		sort.Slice(keysForFields, func(i, j int) bool {
+			return keysForFields[i] < keysForFields[j]
+		})
+		for iNdEx := len(keysForFields) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Fields[string(keysForFields[iNdEx])]
+			baseI := i
+			size, err := (*Value)(v).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFields[iNdEx])
+			copy(dAtA[i:], keysForFields[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFields[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Value) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Value) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	switch c := m.Kind.(type) {
+	case *structpb.Value_NullValue:
+		size, err := (*Value_NullValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	case *structpb.Value_NumberValue:
+		size, err := (*Value_NumberValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	case *structpb.Value_StringValue:
+		size, err := (*Value_StringValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	case *structpb.Value_BoolValue:
+		size, err := (*Value_BoolValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	case *structpb.Value_StructValue:
+		size, err := (*Value_StructValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	case *structpb.Value_ListValue:
+		size, err := (*Value_ListValue)(c).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Value_NullValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_NullValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NullValue))
+	i--
+	dAtA[i] = 0x8
+	return len(dAtA) - i, nil
+}
+func (m *Value_NumberValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_NumberValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.NumberValue))))
+	i--
+	dAtA[i] = 0x11
+	return len(dAtA) - i, nil
+}
+func (m *Value_StringValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_StringValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.StringValue)
+	copy(dAtA[i:], m.StringValue)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.StringValue)))
+	i--
+	dAtA[i] = 0x1a
+	return len(dAtA) - i, nil
+}
+func (m *Value_BoolValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_BoolValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.BoolValue {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x20
+	return len(dAtA) - i, nil
+}
+func (m *Value_StructValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_StructValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.StructValue != nil {
+		size, err := (*Struct)(m.StructValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Value_ListValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Value_ListValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.ListValue != nil {
+		size, err := (*ListValue)(m.ListValue).MarshalToSizedBufferVTStable(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	return len(dAtA) - i, nil
+}
+func (m *ListValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *ListValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Values) > 0 {
+		for iNdEx := len(m.Values) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*Value)(m.Values[iNdEx]).MarshalToSizedBufferVTStable(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Struct) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Struct) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Struct) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Fields) > 0 {
+		keysForFields := make([]string, 0, len(m.Fields))
+		for k := range m.Fields {
+			keysForFields = append(keysForFields, string(k))
+		}
+		sort.Slice(keysForFields, func(i, j int) bool {
+			return keysForFields[i] < keysForFields[j]
+		})
+		for iNdEx := len(keysForFields) - 1; iNdEx >= 0; iNdEx-- {
+			v := m.Fields[string(keysForFields[iNdEx])]
+			baseI := i
+			size, err := (*Value)(v).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(keysForFields[iNdEx])
+			copy(dAtA[i:], keysForFields[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(keysForFields[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Value) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Value) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m, ok := m.Kind.(*structpb.Value_ListValue); ok {
+		msg := ((*Value_ListValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m, ok := m.Kind.(*structpb.Value_StructValue); ok {
+		msg := ((*Value_StructValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m, ok := m.Kind.(*structpb.Value_BoolValue); ok {
+		msg := ((*Value_BoolValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m, ok := m.Kind.(*structpb.Value_StringValue); ok {
+		msg := ((*Value_StringValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m, ok := m.Kind.(*structpb.Value_NumberValue); ok {
+		msg := ((*Value_NumberValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m, ok := m.Kind.(*structpb.Value_NullValue); ok {
+		msg := ((*Value_NullValue)(m))
+		size, err := msg.MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Value_NullValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_NullValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NullValue))
+	i--
+	dAtA[i] = 0x8
+	return len(dAtA) - i, nil
+}
+func (m *Value_NumberValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_NumberValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= 8
+	binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.NumberValue))))
+	i--
+	dAtA[i] = 0x11
+	return len(dAtA) - i, nil
+}
+func (m *Value_StringValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_StringValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.StringValue)
+	copy(dAtA[i:], m.StringValue)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.StringValue)))
+	i--
+	dAtA[i] = 0x1a
+	return len(dAtA) - i, nil
+}
+func (m *Value_BoolValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_BoolValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i--
+	if m.BoolValue {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x20
+	return len(dAtA) - i, nil
+}
+func (m *Value_StructValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_StructValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.StructValue != nil {
+		size, err := (*Struct)(m.StructValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Value_ListValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Value_ListValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.ListValue != nil {
+		size, err := (*ListValue)(m.ListValue).MarshalToSizedBufferVTStableStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
+	return len(dAtA) - i, nil
+}
+func (m *ListValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *ListValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Values) > 0 {
+		for iNdEx := len(m.Values) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := (*Value)(m.Values[iNdEx]).MarshalToSizedBufferVTStableStrict(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}

--- a/types/known/timestamppb/timestamp_vtproto.pb.go
+++ b/types/known/timestamppb/timestamp_vtproto.pb.go
@@ -85,6 +85,84 @@ func (m *Timestamp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Timestamp) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Timestamp) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Timestamp) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Nanos != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Nanos))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Seconds != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Seconds))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Timestamp) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Timestamp) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Timestamp) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Nanos != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Nanos))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Seconds != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Seconds))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Timestamp) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil

--- a/types/known/wrapperspb/wrappers_vtproto.pb.go
+++ b/types/known/wrapperspb/wrappers_vtproto.pb.go
@@ -542,6 +542,640 @@ func (m *BytesValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *DoubleValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DoubleValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *DoubleValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FloatValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FloatValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *FloatValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Value))))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int64Value) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int64Value) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Int64Value) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UInt64Value) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UInt64Value) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UInt64Value) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int32Value) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int32Value) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *Int32Value) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UInt32Value) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UInt32Value) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *UInt32Value) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BoolValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BoolValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *BoolValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value {
+		i--
+		if m.Value {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *StringValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BytesValue) MarshalVTStable() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStable(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BytesValue) MarshalToVTStable(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStable(dAtA[:size])
+}
+
+func (m *BytesValue) MarshalToSizedBufferVTStable(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DoubleValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DoubleValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *DoubleValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FloatValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FloatValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *FloatValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Value))))
+		i--
+		dAtA[i] = 0xd
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int64Value) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int64Value) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Int64Value) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UInt64Value) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UInt64Value) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UInt64Value) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Int32Value) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Int32Value) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *Int32Value) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UInt32Value) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UInt32Value) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *UInt32Value) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BoolValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BoolValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *BoolValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Value {
+		i--
+		if m.Value {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *StringValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BytesValue) MarshalVTStableStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BytesValue) MarshalToVTStableStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStableStrict(dAtA[:size])
+}
+
+func (m *BytesValue) MarshalToSizedBufferVTStableStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *DoubleValue) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil


### PR DESCRIPTION
## Description
Hi, I am currently trying to apply the [SpiceDB](https://github.com/authzed/spicedb), which utilize `vtprotovuf` to marshal/unmarshal the db records. Unfortunately, the data itself contains some map fields, which in result will create the un-deterministic serialized results and mess things up when trying to determine whether the data is updated or not.
(https://github.com/authzed/spicedb/blob/5d0eb901634999bbccc7269af2ea582872812a6b/pkg/diff/caveats/diff.go#L155)

In short, I wish to have a plugin being able to support deterministic marshaling behaviors, just like what was mentioned in the issue: https://github.com/planetscale/vtprotobuf/issues/82.

The PR adjusted the marshal plugin like the one in https://github.com/planetscale/vtprotobuf/pull/44.
