### PR TITLE
Setup golangci lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
       with:
         go-version: '>=1.23.0'
-
-    - uses: actions/checkout@v2
 
     - name: Cache protobuf build
       id: protocache
@@ -32,7 +32,9 @@ jobs:
     - run: make install && go mod tidy && go mod verify
     - run: git --no-pager diff --exit-code
 
-    - run: go vet ./...
+    - uses: golangci/golangci-lint-action@v5
+      with:
+        args: --verbose
 
     - run: make genall
     - run: git --no-pager diff --exit-code

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+linters:
+  disable:
+    - ineffassign
+    - staticcheck
+    - unused
+  enable:
+    - gosimple
+    - govet

--- a/conformance/internal/conformance/mutate_fields.go
+++ b/conformance/internal/conformance/mutate_fields.go
@@ -85,7 +85,6 @@ func mut(t reflect.Type, v reflect.Value) {
 		}
 		v.Set(m)
 	}
-	return
 }
 
 // VisitWithPredicate deep-visits the given struct


### PR DESCRIPTION
Use golangci-lint action instead of only go vet.
It’s now included in golangci-lint config.
It also enables the gosimple linter
The linters with errors are disabled so the step is passing. They can be fixed in an individual pr for each linter.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>