### PR TITLE
.github: bump Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.19'
+        go-version: '>=1.23.0'
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
https://github.com/planetscale/vtprotobuf/pull/140 requires >=1.23.0