### PR TITLE
pool: Reuse unknownFields memory

### DIFF
--- a/features/pool/pool.go
+++ b/features/pool/pool.go
@@ -50,6 +50,7 @@ func (p *pool) message(message *protogen.Message) {
 	p.P(`func (m *`, ccTypeName, `) ResetVT() {`)
 	p.P(`if m != nil {`)
 	var saved []*protogen.Field
+	p.P("f0 := m.unknownFields[:0]")
 	for _, field := range message.Fields {
 		fieldName := field.GoName
 
@@ -64,7 +65,7 @@ func (p *pool) message(message *protogen.Message) {
 				}
 				p.P(`}`)
 			}
-			p.P(fmt.Sprintf("f%d", len(saved)), ` := m.`, fieldName, `[:0]`)
+			p.P(fmt.Sprintf("f%d", len(saved)+1), ` := m.`, fieldName, `[:0]`)
 			saved = append(saved, field)
 		} else if field.Oneof != nil && !field.Oneof.Desc.IsSynthetic() {
 			if p.ShouldPool(field.Message) {
@@ -86,8 +87,9 @@ func (p *pool) message(message *protogen.Message) {
 	}
 
 	p.P(`m.Reset()`)
+	p.P("m.unknownFields = f0")
 	for i, field := range saved {
-		p.P(`m.`, field.GoName, ` = `, fmt.Sprintf("f%d", i))
+		p.P(`m.`, field.GoName, ` = `, fmt.Sprintf("f%d", i+1))
 	}
 	p.P(`}`)
 	p.P(`}`)


### PR DESCRIPTION
First of all: Thanks for the great project! I really like the approach and have seen great performance improvements with vtprotobuf.

While analysing the memory usage of my program using vtprotobuf, I noticed that massive amounts of memory are used for the allocation of `unknownFields`. This is a big part of my data, as I am parsing some existing protobuf (open streetmap's PBF files) where I don't care about a lot of the fields, so I have excluded them from my .proto files to increase performance. Reusing the memory of the `unknownFields` reduced the amount of allocations by 34% and the amount of used memory by 41% in my case.

I'm pretty sure this PR is in no shape to be merged, because I still understand too little about the code to write it better, but thought a working PR would demonstrate my idea better than an issue.